### PR TITLE
강남역 등 주요 다이소 매장 sitemap과 SEO JSON-LD 추가

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'/Users/user/Documents/daiso-finder/.codex/hooks/git-commit-author.sh'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'/Users/user/Documents/daiso-finder/.codex/hooks/git-commit-author.sh'",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/git-commit-author.sh
+++ b/.codex/hooks/git-commit-author.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Claude Code Hook: git commit 시 ~/.gitconfig의 author 정보를 강제 적용
+#
+# PreToolUse (Bash) 이벤트에서 실행되며,
+# git commit 명령에 --author 플래그가 없으면 글로벌 gitconfig 기반으로 추가합니다.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# git commit 명령이 아니면 통과
+if ! echo "$COMMAND" | grep -qE '^\s*git\s+commit\b|&&\s*git\s+commit\b|;\s*git\s+commit\b'; then
+  exit 0
+fi
+
+# 이미 --author 플래그가 있으면 통과
+if echo "$COMMAND" | grep -q '\-\-author'; then
+  exit 0
+fi
+
+# 글로벌 gitconfig에서 user 정보 읽기
+GIT_USER_NAME=$(git config --global user.name 2>/dev/null || true)
+GIT_USER_EMAIL=$(git config --global user.email 2>/dev/null || true)
+
+if [ -z "$GIT_USER_NAME" ] || [ -z "$GIT_USER_EMAIL" ]; then
+  echo "Warning: ~/.gitconfig에 user.name 또는 user.email이 설정되지 않았습니다." >&2
+  exit 0
+fi
+
+# git commit 명령에 --author 플래그 추가
+AUTHOR_FLAG="--author=\"${GIT_USER_NAME} <${GIT_USER_EMAIL}>\""
+MODIFIED_COMMAND=$(echo "$COMMAND" | sed "s/git commit/git commit ${AUTHOR_FLAG}/")
+
+# updatedInput으로 수정된 명령 반환
+jq -n \
+  --arg cmd "$MODIFIED_COMMAND" \
+  --argjson original_input "$(echo "$INPUT" | jq '.tool_input')" \
+  '{
+    "hookSpecificOutput": {
+      "permissionDecision": "allow",
+      "updatedInput": ($original_input | .command = $cmd)
+    }
+  }'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Daiso Finder is a Next.js 14 PWA (App Router) that helps users find Daiso stores and search for product stock/location within stores. Written in TypeScript, styled with PandaCSS + Tabler UI.
+
+## Commands
+
+- **Dev server:** `pnpm dev`
+- **Build:** `pnpm build`
+- **Lint:** `pnpm lint`
+- **PandaCSS codegen:** `pnpm prepare` (run after changing panda.config.ts or when styled-system is stale)
+
+No test framework is configured.
+
+## Architecture
+
+### API Proxy Pattern
+
+All external Daiso API calls are proxied through Next.js API routes (`src/app/api/`) to avoid CORS and limit exposed data. The external API base URL is set via `NEXT_PUBLIC_API_URL` in `.env`.
+
+- `GET /api/branches/search` — search stores by keyword or GPS coordinates (infinite scroll)
+- `GET /api/branches/[code]` — get single store details
+- `GET /api/products` — multi-step: search products → check stock → get shelf placement, returns only in-stock items
+
+### Pages
+
+- `/` (home) — store selector with keyword search and geolocation-based search, infinite scroll pagination
+- `/branch/[code]` — store detail page with product search showing price, stock count, floor/zone info
+
+### Client State
+
+React Query (`@tanstack/react-query`) handles all server state, caching, and pagination. Provider is in `src/app/provider.tsx`.
+
+### Styling
+
+- **PandaCSS** for CSS-in-JS — use `css()` from `@styled-system/css`
+- **Tabler UI** for pre-built components and layout
+- Generated styles live in `styled-system/` (gitignored, regenerated via `pnpm prepare`)
+- Theme color: **#e60033**
+- Font: Pretendard (Korean)
+
+### Path Aliases
+
+- `@/*` → `./src/*`
+- `@styled-system/*` → `./styled-system/*`
+
+## Development Rules
+
+- Package manager: **pnpm** (do not use npm/yarn)
+- Node version: 22.17.1 (see .nvmrc)
+- Prefer Tabler UI components and utilities before adding new UI libraries — see https://docs.tabler.io/ui
+- Check existing dependencies in package.json before installing new packages
+- Next.js config uses `next.config.js` (not .mjs/.ts) with JSDoc types
+- Remote images allowed from `cdn.daisomall.co.kr`

--- a/src/app/branch/[code]/page.tsx
+++ b/src/app/branch/[code]/page.tsx
@@ -1,9 +1,12 @@
 import { SimplifiedBranch } from "@/app/api/branches/types";
+import { branchSearchKeywords, popularBranches } from "@/lib/seoBranches";
 import type { Metadata } from "next";
 import { BranchClient } from "./BranchClient";
 
 function getBaseUrl() {
-  if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL;
+  if (process.env.NEXT_PUBLIC_APP_URL) {
+    return process.env.NEXT_PUBLIC_APP_URL.replace(/\/$/, "");
+  }
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
   return "http://localhost:3000";
 }
@@ -32,12 +35,27 @@ export async function generateMetadata({
   }
 
   const title = `${branch.name} 상품 재고 확인`;
-  const description = `${branch.name}(${branch.address}) 다이소 매장의 상품 재고를 확인하세요. 영업시간 ${branch.openTime} ~ ${branch.closeTime}`;
+  const popularBranch = popularBranches.find(
+    (item) => item.code === params.code,
+  );
+  const localKeywords = popularBranch?.keywords ?? [
+    `다이소 ${branch.name}`,
+    `${branch.name} 다이소`,
+    `${branch.name} 재고 확인`,
+  ];
+  const description = `${branch.name}(${branch.address}) 다이소 매장의 상품 재고, 가격, 층별 진열 위치를 확인하세요. 영업시간 ${branch.openTime} ~ ${branch.closeTime}`;
   const url = `${getBaseUrl()}/branch/${params.code}`;
 
   return {
     title,
     description,
+    keywords: [
+      ...localKeywords,
+      ...branchSearchKeywords,
+      `${branch.name} 상품 찾기`,
+      `${branch.name} 상품 위치`,
+      `${branch.name} 영업시간`,
+    ],
     alternates: { canonical: url },
     openGraph: {
       title,
@@ -67,30 +85,75 @@ export default async function BranchPage({
   params: { code: string };
 }) {
   const branch = await getBranch(params.code);
+  const popularBranch = popularBranches.find(
+    (item) => item.code === params.code,
+  );
+  const localKeywords = branch
+    ? (popularBranch?.keywords ?? [
+        `다이소 ${branch.name}`,
+        `${branch.name} 다이소`,
+        `${branch.name} 재고 확인`,
+      ])
+    : [];
+  const pageUrl = `${getBaseUrl()}/branch/${params.code}`;
 
   const jsonLd = branch
     ? {
         "@context": "https://schema.org",
-        "@type": "Store",
-        name: branch.name,
-        description: `다이소 ${branch.name} 매장`,
-        address: {
-          "@type": "PostalAddress",
-          streetAddress: branch.address,
-          addressCountry: "KR",
-        },
-        openingHours: `Mo-Su ${branch.openTime}-${branch.closeTime}`,
-        geo: {
-          "@type": "GeoCoordinates",
-          latitude: branch.lat,
-          longitude: branch.lng,
-        },
-        url: `${getBaseUrl()}/branch/${params.code}`,
-        parentOrganization: {
-          "@type": "Organization",
-          name: "다이소",
-          url: "https://www.daisomall.co.kr",
-        },
+        "@graph": [
+          {
+            "@type": "Store",
+            "@id": `${pageUrl}#store`,
+            name: `다이소 ${branch.name}`,
+            description: `다이소 ${branch.name} 매장의 상품 재고, 가격, 진열 위치, 영업시간 정보`,
+            address: {
+              "@type": "PostalAddress",
+              streetAddress: branch.address,
+              addressCountry: "KR",
+            },
+            openingHours: `Mo-Su ${branch.openTime}-${branch.closeTime}`,
+            geo: {
+              "@type": "GeoCoordinates",
+              latitude: branch.lat,
+              longitude: branch.lng,
+            },
+            url: pageUrl,
+            keywords: [...localKeywords, ...branchSearchKeywords].join(", "),
+            parentOrganization: {
+              "@type": "Organization",
+              name: "다이소",
+              url: "https://www.daisomall.co.kr",
+            },
+          },
+          {
+            "@type": "WebPage",
+            "@id": `${pageUrl}#webpage`,
+            url: pageUrl,
+            name: `${branch.name} 다이소 상품 재고 확인`,
+            description: `${branch.name} 매장의 다이소 상품 재고, 가격, 층별 진열 위치를 확인하세요.`,
+            inLanguage: "ko-KR",
+            about: { "@id": `${pageUrl}#store` },
+            keywords: [...localKeywords, ...branchSearchKeywords].join(", "),
+          },
+          {
+            "@type": "BreadcrumbList",
+            "@id": `${pageUrl}#breadcrumb`,
+            itemListElement: [
+              {
+                "@type": "ListItem",
+                position: 1,
+                name: "다이소 파인더",
+                item: getBaseUrl(),
+              },
+              {
+                "@type": "ListItem",
+                position: 2,
+                name: `다이소 ${branch.name}`,
+                item: pageUrl,
+              },
+            ],
+          },
+        ],
       }
     : null;
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,15 @@ import "./globals.css";
 import { GoogleAnalytics } from "./GoogleAnalytics";
 import Provider from "./provider";
 import { WebMCP } from "./webmcp";
+import { branchSearchKeywords, popularBranches } from "@/lib/seoBranches";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const APP_URL = (
+  process.env.NEXT_PUBLIC_APP_URL ||
+  (process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : "http://localhost:3000")
+).replace(/\/$/, "");
 
 const pretendard = localFont({
   src: "./PretendardVariable.woff2",
@@ -15,44 +22,60 @@ const pretendard = localFont({
 
 const webAppJsonLd = {
   "@context": "https://schema.org",
-  "@type": "WebApplication",
-  name: "다이소 파인더",
-  description:
-    "다이소 매장의 상품 재고를 실시간으로 확인하세요. 내 주변 매장에 원하는 상품이 있는지 빠르게 찾아드립니다.",
-  applicationCategory: "ShoppingApplication",
-  operatingSystem: "All",
-  offers: { "@type": "Offer", price: "0", priceCurrency: "KRW" },
-  inLanguage: "ko-KR",
-  audience: {
-    "@type": "Audience",
-    audienceType: "Korean shoppers",
-    geographicArea: { "@type": "Country", name: "South Korea" },
-  },
+  "@graph": [
+    {
+      "@type": "WebApplication",
+      "@id": `${APP_URL}/#webapp`,
+      name: "다이소 파인더",
+      description:
+        "다이소 매장의 상품 재고, 가격, 진열 위치를 확인하고 내 주변 매장을 빠르게 찾을 수 있습니다.",
+      applicationCategory: "ShoppingApplication",
+      operatingSystem: "All",
+      offers: { "@type": "Offer", price: "0", priceCurrency: "KRW" },
+      inLanguage: "ko-KR",
+      audience: {
+        "@type": "Audience",
+        audienceType: "Korean shoppers",
+        geographicArea: { "@type": "Country", name: "South Korea" },
+      },
+      keywords: branchSearchKeywords.join(", "),
+    },
+    {
+      "@type": "ItemList",
+      "@id": `${APP_URL}/#popular-branches`,
+      name: "다이소 주요 인기 매장",
+      itemListElement: popularBranches.map((branch, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `${APP_URL}/branch/${branch.code}`,
+        name: `다이소 ${branch.name}`,
+      })),
+    },
+  ],
 };
 
 export const metadata: Metadata = {
+  metadataBase: new URL(APP_URL),
   title: {
     default: "다이소 상품 찾기 | 다이소 파인더",
     template: "%s | 다이소 파인더",
   },
   description:
-    "다이소 매장의 상품 재고를 실시간으로 확인하세요. 내 주변 매장에 원하는 상품이 있는지 빠르게 찾아드립니다.",
+    "다이소 매장의 상품 재고, 가격, 층별 진열 위치를 확인하세요. 강남역, 명동, 홍대, 신촌, 잠실 등 주요 매장에서 원하는 상품을 빠르게 찾아드립니다.",
   manifest: "/manifest.json",
   applicationName: "다이소 파인더",
   keywords: [
     "다이소",
-    "다이소 상품 찾기",
-    "다이소 재고 확인",
-    "다이소 매장 찾기",
-    "다이소 위치",
-    "다이소 재고",
+    ...branchSearchKeywords,
+    ...popularBranches.flatMap((branch) => branch.keywords),
   ],
   authors: [{ name: "다이소 파인더" }],
+  alternates: { canonical: "/" },
   formatDetection: { telephone: false },
   openGraph: {
     title: "다이소 상품 찾기 | 다이소 파인더",
     description:
-      "다이소 매장의 상품 재고를 실시간으로 확인하세요. 내 주변 매장에 원하는 상품이 있는지 빠르게 찾아드립니다.",
+      "다이소 매장의 상품 재고, 가격, 층별 진열 위치를 확인하세요. 내 주변 매장에 원하는 상품이 있는지 빠르게 찾아드립니다.",
     siteName: "다이소 파인더",
     locale: "ko_KR",
     type: "website",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,11 @@ import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { SimplifiedBranchResponse } from "./api/branches/types";
 import { Search } from "@/components/Search";
 import { trackEvent } from "@/lib/gtag";
+import { popularBranches } from "@/lib/seoBranches";
+
+const APP_URL = (
+  process.env.NEXT_PUBLIC_APP_URL || "https://daiso-finder.vercel.app"
+).replace(/\/$/, "");
 
 export default function Home() {
   const [searchInput, setSearchInput] = useState("");
@@ -56,6 +61,17 @@ export default function Home() {
     () => data?.pages.flatMap((page) => page) ?? [],
     [data],
   );
+  const popularBranchesJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "다이소 주요 인기 매장 바로가기",
+    itemListElement: popularBranches.map((branch, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: `다이소 ${branch.name} 재고 확인`,
+      url: `${APP_URL}/branch/${branch.code}`,
+    })),
+  };
 
   const getCurrentPosition = async () => {
     if (!navigator.geolocation) {
@@ -159,6 +175,12 @@ export default function Home() {
         flexDirection: "column",
       })}
     >
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(popularBranchesJsonLd),
+        }}
+      />
       <Image
         src="/logo.svg"
         alt="다이소 파인더 로고"
@@ -178,6 +200,42 @@ export default function Home() {
         })}
       />
       <h1>당신이 있는 매장의 상품을 찾아드립니다</h1>
+      <nav
+        aria-label="주요 다이소 매장"
+        className={css({
+          display: "flex",
+          gap: "6px",
+          overflowX: "auto",
+          paddingBottom: "12px",
+          marginBottom: "4px",
+          scrollbarWidth: "none",
+          "&::-webkit-scrollbar": { display: "none" },
+        })}
+      >
+        {popularBranches.map((branch) => (
+          <Link
+            key={branch.code}
+            href={`/branch/${branch.code}`}
+            className={css({
+              flexShrink: 0,
+              padding: "6px 10px",
+              border: "1px solid #e4e4e4",
+              borderRadius: "999px",
+              backgroundColor: "white",
+              color: "#333",
+              fontSize: "0.8125rem",
+              textDecoration: "none",
+              lineHeight: 1.2,
+              _hover: {
+                borderColor: "#ED1C24",
+                color: "#ED1C24",
+              },
+            })}
+          >
+            {branch.name}
+          </Link>
+        ))}
+      </nav>
       <Search
         title="매장을 선택해주세요"
         placeholder="주소 혹은 지점명을 입력하세요"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { css } from "@styled-system/css";
 import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
+import { IconMapPinFilled } from "@tabler/icons-react";
 import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
@@ -187,9 +188,9 @@ export default function Home() {
         width={200}
         height={80}
         draggable={false}
-        style={{ WebkitUserDrag: 'none' } as React.CSSProperties}
+        style={{ WebkitUserDrag: "none" } as React.CSSProperties}
         className={css({
-          userSelect: 'none',
+          userSelect: "none",
           marginBottom: "24px",
           width: "150px",
           height: "60px",
@@ -204,11 +205,15 @@ export default function Home() {
         aria-label="주요 다이소 매장"
         className={css({
           display: "flex",
-          gap: "6px",
+          gap: "8px",
           overflowX: "auto",
-          paddingBottom: "12px",
-          marginBottom: "4px",
+          padding: "2px 1px 14px",
+          marginBottom: "2px",
           scrollbarWidth: "none",
+          WebkitMaskImage:
+            "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
+          maskImage:
+            "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
           "&::-webkit-scrollbar": { display: "none" },
         })}
       >
@@ -217,21 +222,47 @@ export default function Home() {
             key={branch.code}
             href={`/branch/${branch.code}`}
             className={css({
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "5px",
               flexShrink: 0,
-              padding: "6px 10px",
-              border: "1px solid #e4e4e4",
+              minHeight: "34px",
+              padding: "7px 11px 7px 9px",
+              border: "1px solid rgba(237, 28, 36, 0.14)",
               borderRadius: "999px",
-              backgroundColor: "white",
-              color: "#333",
-              fontSize: "0.8125rem",
+              backgroundColor: "rgba(255, 255, 255, 0.94)",
+              color: "#272a31",
+              boxShadow:
+                "0 1px 2px rgba(20, 24, 32, 0.06), 0 7px 18px rgba(237, 28, 36, 0.07)",
+              fontSize: "0.825rem",
+              fontWeight: 700,
               textDecoration: "none",
               lineHeight: 1.2,
+              transition:
+                "transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease, color 160ms ease",
               _hover: {
-                borderColor: "#ED1C24",
+                transform: "translateY(-1px)",
+                borderColor: "rgba(237, 28, 36, 0.36)",
+                backgroundColor: "#fff7f8",
                 color: "#ED1C24",
+                boxShadow:
+                  "0 4px 10px rgba(20, 24, 32, 0.08), 0 10px 24px rgba(237, 28, 36, 0.12)",
+              },
+              _focusVisible: {
+                outline: "2px solid rgba(237, 28, 36, 0.35)",
+                outlineOffset: "2px",
               },
             })}
           >
+            <IconMapPinFilled
+              aria-hidden="true"
+              width={13}
+              height={13}
+              className={css({
+                color: "#ED1C24",
+                flexShrink: 0,
+              })}
+            />
             {branch.name}
           </Link>
         ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -221,38 +221,39 @@ export default function Home() {
           <Link
             key={branch.code}
             href={`/branch/${branch.code}`}
-            className={css({
-              display: "inline-flex",
-              alignItems: "center",
-              gap: "5px",
-              flexShrink: 0,
-              minHeight: "34px",
-              padding: "7px 11px 7px 9px",
-              border: "1px solid rgba(237, 28, 36, 0.14)",
-              borderRadius: "999px",
-              backgroundColor: "rgba(255, 255, 255, 0.94)",
-              color: "#272a31",
-              boxShadow:
-                "0 1px 2px rgba(20, 24, 32, 0.06), 0 7px 18px rgba(237, 28, 36, 0.07)",
-              fontSize: "0.825rem",
-              fontWeight: 700,
-              textDecoration: "none",
-              lineHeight: 1.2,
-              transition:
-                "transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease, color 160ms ease",
-              _hover: {
-                transform: "translateY(-1px)",
-                borderColor: "rgba(237, 28, 36, 0.36)",
-                backgroundColor: "#fff7f8",
-                color: "#ED1C24",
+            className={clsx(
+              "badge bg-red-lt",
+              css({
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "5px",
+                flexShrink: 0,
+                minHeight: "34px",
+                padding: "7px 11px 7px 9px",
+                borderColor: "rgba(237, 28, 36, 0.16)",
+                borderRadius: "999px",
                 boxShadow:
-                  "0 4px 10px rgba(20, 24, 32, 0.08), 0 10px 24px rgba(237, 28, 36, 0.12)",
-              },
-              _focusVisible: {
-                outline: "2px solid rgba(237, 28, 36, 0.35)",
-                outlineOffset: "2px",
-              },
-            })}
+                  "0 1px 2px rgba(20, 24, 32, 0.06), 0 7px 18px rgba(237, 28, 36, 0.07)",
+                fontSize: "0.825rem",
+                fontWeight: 700,
+                textDecoration: "none",
+                lineHeight: 1.2,
+                transition:
+                  "transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease, color 160ms ease",
+                _hover: {
+                  transform: "translateY(-1px)",
+                  borderColor: "rgba(237, 28, 36, 0.38)",
+                  backgroundColor: "#fff7f8",
+                  color: "#ED1C24",
+                  boxShadow:
+                    "0 4px 10px rgba(20, 24, 32, 0.08), 0 10px 24px rgba(237, 28, 36, 0.12)",
+                },
+                _focusVisible: {
+                  outline: "2px solid rgba(237, 28, 36, 0.35)",
+                  outlineOffset: "2px",
+                },
+              }),
+            )}
           >
             <IconMapPinFilled
               aria-hidden="true"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -201,73 +201,6 @@ export default function Home() {
         })}
       />
       <h1>당신이 있는 매장의 상품을 찾아드립니다</h1>
-      <nav
-        aria-label="주요 다이소 매장"
-        className={css({
-          display: "flex",
-          gap: "8px",
-          overflowX: "auto",
-          padding: "2px 1px 14px",
-          marginBottom: "2px",
-          scrollbarWidth: "none",
-          WebkitMaskImage:
-            "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
-          maskImage:
-            "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
-          "&::-webkit-scrollbar": { display: "none" },
-        })}
-      >
-        {popularBranches.map((branch) => (
-          <Link
-            key={branch.code}
-            href={`/branch/${branch.code}`}
-            className={clsx(
-              "badge bg-red-lt",
-              css({
-                display: "inline-flex",
-                alignItems: "center",
-                gap: "5px",
-                flexShrink: 0,
-                minHeight: "34px",
-                padding: "7px 11px 7px 9px",
-                borderColor: "rgba(237, 28, 36, 0.16)",
-                borderRadius: "999px",
-                boxShadow:
-                  "0 1px 2px rgba(20, 24, 32, 0.06), 0 7px 18px rgba(237, 28, 36, 0.07)",
-                fontSize: "0.825rem",
-                fontWeight: 700,
-                textDecoration: "none",
-                lineHeight: 1.2,
-                transition:
-                  "transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease, color 160ms ease",
-                _hover: {
-                  transform: "translateY(-1px)",
-                  borderColor: "rgba(237, 28, 36, 0.38)",
-                  backgroundColor: "#fff7f8",
-                  color: "#ED1C24",
-                  boxShadow:
-                    "0 4px 10px rgba(20, 24, 32, 0.08), 0 10px 24px rgba(237, 28, 36, 0.12)",
-                },
-                _focusVisible: {
-                  outline: "2px solid rgba(237, 28, 36, 0.35)",
-                  outlineOffset: "2px",
-                },
-              }),
-            )}
-          >
-            <IconMapPinFilled
-              aria-hidden="true"
-              width={13}
-              height={13}
-              className={css({
-                color: "#ED1C24",
-                flexShrink: 0,
-              })}
-            />
-            {branch.name}
-          </Link>
-        ))}
-      </nav>
       <Search
         title="매장을 선택해주세요"
         placeholder="주소 혹은 지점명을 입력하세요"
@@ -278,13 +211,68 @@ export default function Home() {
         hasResults={branches.length > 0}
         keyword={keyword}
         withLocation
+        beforeForm={
+          <nav
+            aria-label="주요 다이소 매장"
+            className={css({
+              display: "flex",
+              gap: "10px",
+              overflowX: "auto",
+              paddingBlock: 4,
+              paddingInline: 4,
+              marginBottom: "10px",
+              scrollbarWidth: "none",
+              WebkitMaskImage:
+                "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
+              maskImage:
+                "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
+              "&::-webkit-scrollbar": { display: "none" },
+            })}
+          >
+            {popularBranches.map((branch) => (
+              <Link
+                key={branch.code}
+                href={`/branch/${branch.code}`}
+                className={clsx(
+                  "badge bg-red-lt",
+                  css({
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "6px",
+                    flexShrink: 0,
+                    minHeight: "32px",
+                    padding: "7px 11px",
+                    fontSize: "0.875rem",
+                    lineHeight: 1.2,
+                  }),
+                )}
+              >
+                <IconMapPinFilled
+                  aria-hidden="true"
+                  width={15}
+                  height={15}
+                  className={css({
+                    color: "#ED1C24",
+                    flexShrink: 0,
+                  })}
+                />
+                {branch.name}
+              </Link>
+            ))}
+          </nav>
+        }
       >
         {branches?.map((branch) => (
           <Link
             href={`/branch/${branch.code}`}
             className="card"
             key={branch.code}
-            onClick={() => trackEvent("branch_click", { branch_code: branch.code, branch_name: branch.name })}
+            onClick={() =>
+              trackEvent("branch_click", {
+                branch_code: branch.code,
+                branch_name: branch.name,
+              })
+            }
           >
             <div className="card-body">
               <h5 className="card-title">{branch.name}</h5>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import { MetadataRoute } from "next";
+import { popularBranches } from "@/lib/seoBranches";
 
 function getBaseUrl() {
   if (process.env.NEXT_PUBLIC_APP_URL) return process.env.NEXT_PUBLIC_APP_URL;
@@ -7,7 +8,7 @@ function getBaseUrl() {
 }
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const base = getBaseUrl();
+  const base = getBaseUrl().replace(/\/$/, "");
   return [
     {
       url: base,
@@ -15,5 +16,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 1,
     },
+    ...popularBranches.map((branch) => ({
+      url: `${base}/branch/${branch.code}`,
+      lastModified: new Date(),
+      changeFrequency: "daily" as const,
+      priority: 0.85,
+    })),
   ];
 }

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -12,6 +12,7 @@ interface SearchProps {
   onSearchInputChange: (value: string) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   children: ReactNode;
+  beforeForm?: ReactNode;
   isFetching?: boolean;
   hasResults?: boolean;
   keyword?: string;
@@ -25,6 +26,7 @@ export function Search({
   onSearchInputChange,
   onSubmit,
   children,
+  beforeForm,
   isFetching,
   hasResults,
   keyword,
@@ -43,6 +45,7 @@ export function Search({
       >
         {title}
       </span>
+      {beforeForm}
       <form
         className={clsx("input-group", css({ marginBottom: "12px" }))}
         onSubmit={onSubmit}

--- a/src/lib/seoBranches.ts
+++ b/src/lib/seoBranches.ts
@@ -1,0 +1,120 @@
+export type PopularBranch = {
+  code: string;
+  name: string;
+  city: string;
+  district: string;
+  address: string;
+  keywords: string[];
+};
+
+export const popularBranches: PopularBranch[] = [
+  {
+    code: "11199",
+    name: "강남역점",
+    city: "서울",
+    district: "강남",
+    address: "서울특별시 강남구 강남대로 422 (역삼동)",
+    keywords: ["다이소 강남역", "강남 다이소", "강남역 다이소 재고"],
+  },
+  {
+    code: "10528",
+    name: "명동본점",
+    city: "서울",
+    district: "명동",
+    address: "서울특별시 중구 명동길 43 (명동1가)",
+    keywords: ["다이소 명동", "명동 다이소", "명동 다이소 상품 위치"],
+  },
+  {
+    code: "10962",
+    name: "홍대입구점",
+    city: "서울",
+    district: "홍대",
+    address: "서울특별시 마포구 홍익로 25 (서교동)",
+    keywords: ["다이소 홍대", "홍대입구 다이소", "홍대 다이소 재고"],
+  },
+  {
+    code: "10595",
+    name: "신촌본점",
+    city: "서울",
+    district: "신촌",
+    address: "서울특별시 마포구 신촌로 90 (노고산동)",
+    keywords: ["다이소 신촌", "신촌 다이소", "신촌 다이소 재고 확인"],
+  },
+  {
+    code: "10087",
+    name: "잠실점",
+    city: "서울",
+    district: "잠실",
+    address: "서울특별시 송파구 석촌호수로 88 (잠실동)",
+    keywords: ["다이소 잠실", "잠실 다이소", "잠실 다이소 상품 찾기"],
+  },
+  {
+    code: "11015",
+    name: "서울역점",
+    city: "서울",
+    district: "서울역",
+    address: "서울특별시 중구 한강대로 405(봉래동2가)",
+    keywords: ["다이소 서울역", "서울역 다이소", "서울역 다이소 재고"],
+  },
+  {
+    code: "10440",
+    name: "부산서면점",
+    city: "부산",
+    district: "서면",
+    address: "부산광역시 부산진구 중앙대로702번길 43 (부전동)",
+    keywords: ["다이소 서면", "부산 서면 다이소", "서면 다이소 재고"],
+  },
+  {
+    code: "10502",
+    name: "부산해운대점",
+    city: "부산",
+    district: "해운대",
+    address: "부산광역시 해운대구 구남로 11 (우동)",
+    keywords: ["다이소 해운대", "부산 해운대 다이소", "해운대 다이소 상품 위치"],
+  },
+  {
+    code: "10610",
+    name: "대구동성로본점",
+    city: "대구",
+    district: "동성로",
+    address: "대구광역시 중구 동성로 48-1 (동성로2가)",
+    keywords: ["다이소 동성로", "대구 동성로 다이소", "동성로 다이소 재고"],
+  },
+  {
+    code: "10626",
+    name: "대전본점",
+    city: "대전",
+    district: "동구",
+    address: "대전광역시 동구 동서대로1695번길 8 (용전동)",
+    keywords: ["다이소 대전", "대전본점 다이소", "대전 다이소 재고"],
+  },
+  {
+    code: "11042",
+    name: "광주광천점",
+    city: "광주",
+    district: "광천",
+    address: "광주 서구 죽봉대로 122",
+    keywords: ["다이소 광주", "광주광천 다이소", "광주 다이소 재고 확인"],
+  },
+  {
+    code: "10152",
+    name: "제주본점",
+    city: "제주",
+    district: "제주시",
+    address: "제주특별자치도 제주시 남광로 220 (건입동)",
+    keywords: ["다이소 제주", "제주본점 다이소", "제주 다이소 상품 찾기"],
+  },
+];
+
+export const branchSearchKeywords = [
+  "다이소 상품 찾기",
+  "다이소 재고 확인",
+  "다이소 상품 재고",
+  "다이소 매장 재고",
+  "다이소 매장 찾기",
+  "다이소 영업시간",
+  "다이소 상품 위치",
+  "다이소 진열 위치",
+  "다이소 층별 위치",
+  "다이소 구역 찾기",
+];


### PR DESCRIPTION
## Summary
- 주요 인기 매장 12곳을 공용 SEO 데이터로 분리하고, `sitemap.xml`에 각 매장 상세 URL을 추가했습니다.
- 홈과 매장 상세에 검색 의도를 넓히는 키워드, 내부 링크, JSON-LD(`WebApplication`, `ItemList`, `Store`, `WebPage`, `BreadcrumbList`)를 보강했습니다.
- 홈 canonical과 매장별 메타 설명도 함께 정리해서 인덱싱 신호를 더 일관되게 만들었습니다.

## Testing
- `pnpm lint` 통과
- `pnpm build` 통과