### PR TITLE
Improve product location display with icons and labels

### DIFF
--- a/src/app/branch/[code]/BranchClient.tsx
+++ b/src/app/branch/[code]/BranchClient.tsx
@@ -8,7 +8,7 @@ import {
 import { Search } from "@/components/Search";
 import { trackEvent } from "@/lib/gtag";
 import { css } from "@styled-system/css";
-import { IconPhotoX } from "@tabler/icons-react";
+import { IconMapPin, IconPhotoX, IconStairs } from "@tabler/icons-react";
 import {
   InfiniteData,
   useInfiniteQuery,
@@ -281,37 +281,93 @@ export function BranchClient({ code, initialBranch }: Props) {
                 <div
                   className={css({
                     display: "flex",
+                    flexWrap: "wrap",
                     alignItems: "center",
-                    gap: "6px",
+                    justifyContent: "flex-end",
+                    columnGap: "12px",
+                    rowGap: "4px",
                     alignSelf: "flex-end",
                   })}
                   aria-label={`진열 위치: ${product.stairNo < 0 ? `지하${-product.stairNo}층` : `${product.stairNo}층`} ${product.zoneNo}구역`}
                 >
                   <span
                     className={css({
-                      fontWeight: "black",
-                      fontSize: "1.25rem",
-                      color: "#ED1C24",
-                      lineHeight: 1,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "4px",
                     })}
                   >
-                    {product.stairNo < 0
-                      ? `B${-product.stairNo}`
-                      : `${product.stairNo}F`}
+                    <IconStairs
+                      width={16}
+                      height={16}
+                      stroke={2.25}
+                      color="#666"
+                      aria-hidden="true"
+                    />
+                    <span
+                      className={css({
+                        fontSize: "0.75rem",
+                        fontWeight: 500,
+                        color: "#666",
+                        marginRight: "3px",
+                      })}
+                      aria-hidden="true"
+                    >
+                      층
+                    </span>
+                    <span
+                      className={css({
+                        fontWeight: "black",
+                        fontSize: "1.25rem",
+                        color: "#ED1C24",
+                        lineHeight: 1,
+                        fontVariantNumeric: "tabular-nums",
+                      })}
+                    >
+                      {product.stairNo < 0
+                        ? `B${-product.stairNo}`
+                        : `${product.stairNo}F`}
+                    </span>
                   </span>
                   <span
                     className={css({
-                      backgroundColor: "#ED1C24",
-                      color: "white",
-                      padding: "3px 8px",
-                      borderRadius: "4px",
-                      fontSize: "1rem",
-                      fontWeight: "bold",
-                      lineHeight: 1.2,
-                      fontVariantNumeric: "tabular-nums",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "4px",
                     })}
                   >
-                    {product.zoneNo}
+                    <IconMapPin
+                      width={16}
+                      height={16}
+                      stroke={2.25}
+                      color="#666"
+                      aria-hidden="true"
+                    />
+                    <span
+                      className={css({
+                        fontSize: "0.75rem",
+                        fontWeight: 500,
+                        color: "#666",
+                        marginRight: "3px",
+                      })}
+                      aria-hidden="true"
+                    >
+                      구역
+                    </span>
+                    <span
+                      className={css({
+                        backgroundColor: "#ED1C24",
+                        color: "white",
+                        padding: "3px 8px",
+                        borderRadius: "4px",
+                        fontSize: "1rem",
+                        fontWeight: "bold",
+                        lineHeight: 1.2,
+                        fontVariantNumeric: "tabular-nums",
+                      })}
+                    >
+                      {product.zoneNo}
+                    </span>
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
Enhanced the product shelf placement display on the branch detail page by adding descriptive icons and labels for floor and zone information, improving visual clarity and accessibility.

## Key Changes
- Added `IconMapPin` and `IconStairs` imports from Tabler Icons
- Restructured the location display container to support wrapping with improved spacing:
  - Changed from fixed `gap: "6px"` to `columnGap: "12px"` and `rowGap: "4px"`
  - Added `flexWrap: "wrap"` and `justifyContent: "flex-end"` for better responsive layout
- Floor number display now includes:
  - `IconStairs` icon with "층" (floor) label
  - Maintained red (#ED1C24) styling for the floor number itself
  - Added `fontVariantNumeric: "tabular-nums"` for consistent number width
- Zone number display now includes:
  - `IconMapPin` icon with "구역" (zone) label
  - Preserved the red badge styling for the zone number
- Both labels use smaller, muted gray text (#666) with proper icon alignment
- Improved semantic structure with nested spans for better accessibility

## Implementation Details
- Icons are set to 16×16px with 2.25 stroke width for consistency
- Labels are marked with `aria-hidden="true"` to avoid redundancy with existing aria-label
- Maintains existing aria-label for screen readers with full location description
- Layout uses inline-flex for icon + label grouping, allowing proper wrapping at container level

https://claude.ai/code/session_01QiK7eKS7YtUwDxaDVMMnWh