### PR TITLE
지점 상세 서버 조회 오류 수정

### DIFF
--- a/src/app/api/branches/[code]/route.ts
+++ b/src/app/api/branches/[code]/route.ts
@@ -1,4 +1,4 @@
-import { BranchResponse } from "../types";
+import { DaisoBranchApiError, fetchBranchByCode } from "@/lib/daisoBranches";
 
 export async function GET(
   _request: Request,
@@ -7,36 +7,7 @@ export async function GET(
   const code = params.code;
 
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/ms/msg/selStr`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          inclusiveStrCd: code,
-        }),
-      },
-    );
-
-    const responseText = await response.text();
-
-    if (!response.ok) {
-      return new Response(
-        JSON.stringify({
-          error: "매장 정보를 불러오는 중 오류가 발생했습니다.",
-          detail: responseText,
-        }),
-        {
-          status: response.status,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    }
-
-    const data: BranchResponse = JSON.parse(responseText);
-    const branch = data.data[0];
+    const branch = await fetchBranchByCode(code);
 
     if (!branch) {
       return new Response(
@@ -50,23 +21,25 @@ export async function GET(
       );
     }
 
-    return new Response(
-      JSON.stringify({
-        code: branch.strCd,
-        name: branch.strNm,
-        lat: branch.strLttd,
-        lng: branch.strLitd,
-        address: branch.strAddr,
-        openTime: branch.opngTime,
-        closeTime: branch.clsngTime,
-      }),
-      {
-        headers: {
-          "Content-Type": "application/json",
-        },
+    return new Response(JSON.stringify(branch), {
+      headers: {
+        "Content-Type": "application/json",
       },
-    );
+    });
   } catch (error) {
+    if (error instanceof DaisoBranchApiError) {
+      return new Response(
+        JSON.stringify({
+          error: error.message,
+          detail: error.detail,
+        }),
+        {
+          status: error.status,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
     console.error("API 오류:", error);
     return new Response(
       JSON.stringify({

--- a/src/app/branch/[code]/page.tsx
+++ b/src/app/branch/[code]/page.tsx
@@ -1,4 +1,5 @@
 import { SimplifiedBranch } from "@/app/api/branches/types";
+import { fetchBranchByCode } from "@/lib/daisoBranches";
 import { branchSearchKeywords, popularBranches } from "@/lib/seoBranches";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -13,15 +14,7 @@ function getBaseUrl() {
 }
 
 async function getBranch(code: string): Promise<SimplifiedBranch | null> {
-  try {
-    const res = await fetch(`${getBaseUrl()}/api/branches/${code}`, {
-      next: { revalidate: 3600 },
-    });
-    if (!res.ok) return null;
-    return res.json();
-  } catch {
-    return null;
-  }
+  return fetchBranchByCode(code);
 }
 
 export async function generateMetadata({
@@ -29,7 +22,10 @@ export async function generateMetadata({
 }: {
   params: { code: string };
 }): Promise<Metadata> {
-  const branch = await getBranch(params.code);
+  const branch = await getBranch(params.code).catch((error) => {
+    console.error("매장 메타데이터 조회 오류:", error);
+    return null;
+  });
 
   if (!branch) {
     return { title: "매장 정보를 찾을 수 없습니다" };

--- a/src/lib/daisoBranches.ts
+++ b/src/lib/daisoBranches.ts
@@ -1,0 +1,61 @@
+import {
+  Branch,
+  BranchResponse,
+  SimplifiedBranch,
+} from "@/app/api/branches/types";
+
+export class DaisoBranchApiError extends Error {
+  status: number;
+  detail: string;
+
+  constructor(message: string, status: number, detail: string) {
+    super(message);
+    this.name = "DaisoBranchApiError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+export function simplifyBranch(branch: Branch): SimplifiedBranch {
+  return {
+    code: branch.strCd,
+    name: branch.strNm,
+    lat: branch.strLttd,
+    lng: branch.strLitd,
+    address: branch.strAddr,
+    openTime: branch.opngTime,
+    closeTime: branch.clsngTime,
+  };
+}
+
+export async function fetchBranchByCode(
+  code: string,
+): Promise<SimplifiedBranch | null> {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/ms/msg/selStr`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        inclusiveStrCd: code,
+      }),
+    },
+  );
+
+  const responseText = await response.text();
+
+  if (!response.ok) {
+    throw new DaisoBranchApiError(
+      "매장 정보를 불러오는 중 오류가 발생했습니다.",
+      response.status,
+      responseText,
+    );
+  }
+
+  const data: BranchResponse = JSON.parse(responseText);
+  const branch = data.data?.[0];
+
+  return branch ? simplifyBranch(branch) : null;
+}


### PR DESCRIPTION
## 원인
- `/branch/[code]` 서버 컴포넌트가 지점 정보를 가져올 때 `${NEXT_PUBLIC_APP_URL}/api/branches/[code]`로 자기 자신의 API route를 다시 호출하고 있었습니다.
- 배포 환경에서 이 서버 사이드 self-fetch가 실패하면 `getBranch()`가 `null`을 반환하고, 새로 추가된 `notFound()` 분기로 모든 지점 상세가 404/오류 화면으로 떨어졌습니다.
- 실제 `/api/branches/11199`는 정상 응답해서 외부 다이소 API와 API route 자체는 문제가 아니었습니다.

## 변경
- 외부 다이소 API에서 지점 정보를 직접 조회하는 공용 헬퍼를 추가했습니다.
- 상세 페이지와 `/api/branches/[code]` route가 같은 헬퍼를 사용하도록 정리했습니다.
- 이제 정상 지점은 외부 API 직접 조회로 렌더되고, 진짜 없는 지점만 404 처리됩니다.

## 검증
- `./node_modules/.bin/next lint` 통과
- `./node_modules/.bin/tsc --noEmit`은 로컬 `node_modules`의 `minimatch` 타입 정의 누락으로 실행 전 단계에서 실패했습니다.
