### PR TITLE
Add PWA install banner for Android and iOS

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,9 @@
 {
-  "name": "Daiso Finder",
+  "name": "다이소 파인더",
+  "short_name": "다이소 파인더",
+  "description": "다이소 매장의 상품 재고, 가격, 진열 위치를 빠르게 확인하세요.",
+  "lang": "ko-KR",
+  "scope": "/",
   "theme_color": "#ED1C24",
   "background_color": "#ED1C24",
   "start_url": "/",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,6 +18,7 @@ html,
 body {
   width: 100vw;
   height: 100vh;
+  background: rgb(var(--background-rgb));
   @supports (width: 100dvw) {
     width: 100dvw;
     height: 100dvh;
@@ -26,7 +27,6 @@ body {
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: rgb(var(--background-rgb));
   overflow: hidden;
   user-select: none;
   -webkit-user-select: none;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,7 @@
 :root {
   --foreground-rgb: 64, 71, 86;
   --background-rgb: 255, 255, 255;
+  color-scheme: light;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,7 @@ body {
 body {
   color: rgb(var(--foreground-rgb));
   background: rgb(var(--background-rgb));
+  overflow: hidden;
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,6 +64,11 @@ export const metadata: Metadata = {
     "다이소 매장의 상품 재고, 가격, 층별 진열 위치를 확인하세요. 강남역, 명동, 홍대, 신촌, 잠실 등 주요 매장에서 원하는 상품을 빠르게 찾아드립니다.",
   manifest: "/manifest.json",
   applicationName: "다이소 파인더",
+  appleWebApp: {
+    capable: true,
+    title: "다이소 파인더",
+    statusBarStyle: "default",
+  },
   keywords: [
     "다이소",
     ...branchSearchKeywords,

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PWAInstallBanner } from "@/components/PWAInstallBanner";
 import {
   ErrorModalProvider,
   useErrorModal,
@@ -62,6 +63,7 @@ export default function Provider({ children }: { children: React.ReactNode }) {
   return (
     <ErrorModalProvider>
       <QueryProvider>{children}</QueryProvider>
+      <PWAInstallBanner />
     </ErrorModalProvider>
   );
 }

--- a/src/components/PWAInstallBanner.tsx
+++ b/src/components/PWAInstallBanner.tsx
@@ -60,11 +60,11 @@ export function PWAInstallBanner() {
             })}`}
           >
             <Image
-              src="/logo.svg"
+              src="/android-icon-192x192.png"
               alt="다이소 파인더"
               width={40}
               height={40}
-              className={css({ flexShrink: 0 })}
+              className={css({ flexShrink: 0, borderRadius: "8px" })}
             />
             <div className={css({ flex: 1, minWidth: 0 })}>
               <div

--- a/src/components/PWAInstallBanner.tsx
+++ b/src/components/PWAInstallBanner.tsx
@@ -3,28 +3,93 @@
 import { usePWAInstall } from "@/hooks/usePWAInstall";
 import { trackEvent } from "@/lib/gtag";
 import { css } from "@styled-system/css";
-import { IconDownload } from "@tabler/icons-react";
+import {
+  IconCirclePlus,
+  IconDeviceMobile,
+  IconDotsVertical,
+  IconDownload,
+  IconShare3,
+} from "@tabler/icons-react";
 import Image from "next/image";
 import { useState } from "react";
-import { PWAInstallInstructions } from "./PWAInstallInstructions";
+import {
+  PWAInstallInstructions,
+  type PWAInstallStep,
+} from "./PWAInstallInstructions";
+
+type InstructionsKind = "ios" | "android";
+
+const IOS_STEPS: PWAInstallStep[] = [
+  { icon: IconShare3, text: "Safari 하단의 공유 버튼을 탭하세요" },
+  {
+    icon: IconCirclePlus,
+    text: "메뉴에서 '홈 화면에 추가'를 선택하세요",
+  },
+  {
+    icon: IconDeviceMobile,
+    text: "우측 상단의 '추가' 버튼을 탭하면 완료됩니다",
+  },
+];
+
+const ANDROID_STEPS: PWAInstallStep[] = [
+  {
+    icon: IconDotsVertical,
+    text: "우측 상단의 메뉴(︙) 아이콘을 탭하세요",
+  },
+  {
+    icon: IconCirclePlus,
+    text: "'앱 설치' 또는 '홈 화면에 추가'를 선택하세요",
+  },
+  {
+    icon: IconDeviceMobile,
+    text: "'설치' 또는 '추가'를 탭하면 완료됩니다",
+  },
+];
+
+const INSTRUCTIONS_COPY: Record<
+  InstructionsKind,
+  { title: string; description: string; steps: PWAInstallStep[]; viewEvent: string }
+> = {
+  ios: {
+    title: "홈 화면에 추가하기",
+    description:
+      "다이소 파인더를 앱처럼 사용해보세요. 아래 단계대로 따라하시면 홈 화면에 추가됩니다.",
+    steps: IOS_STEPS,
+    viewEvent: "pwa_install_ios_modal_view",
+  },
+  android: {
+    title: "앱으로 설치하기",
+    description:
+      "다이소 파인더를 앱처럼 사용해보세요. 아래 단계대로 따라하시면 홈 화면에 추가됩니다.",
+    steps: ANDROID_STEPS,
+    viewEvent: "pwa_install_chrome_modal_view",
+  },
+};
 
 export function PWAInstallBanner() {
-  const { state, promptInstall, dismiss } = usePWAInstall();
-  const [showIOSInstructions, setShowIOSInstructions] = useState(false);
+  const { state, hasDeferredPrompt, promptInstall, dismiss } = usePWAInstall();
+  const [instructions, setInstructions] = useState<InstructionsKind | null>(
+    null,
+  );
+
+  const closeInstructions = () => setInstructions(null);
 
   if (state === "hidden") {
-    return showIOSInstructions ? (
-      <PWAInstallInstructions onClose={() => setShowIOSInstructions(false)} />
+    return instructions ? (
+      <PWAInstallInstructions
+        {...INSTRUCTIONS_COPY[instructions]}
+        onClose={closeInstructions}
+      />
     ) : null;
   }
 
   const handleInstall = () => {
     trackEvent("pwa_install_banner_click", { platform: state });
-    if (state === "android") {
+    if (state === "android" && hasDeferredPrompt) {
       void promptInstall();
-    } else {
-      setShowIOSInstructions(true);
+      return;
     }
+    setInstructions(state);
   };
 
   return (
@@ -108,8 +173,11 @@ export function PWAInstallBanner() {
           </div>
         </div>
       </div>
-      {showIOSInstructions && (
-        <PWAInstallInstructions onClose={() => setShowIOSInstructions(false)} />
+      {instructions && (
+        <PWAInstallInstructions
+          {...INSTRUCTIONS_COPY[instructions]}
+          onClose={closeInstructions}
+        />
       )}
     </>
   );

--- a/src/components/PWAInstallBanner.tsx
+++ b/src/components/PWAInstallBanner.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { usePWAInstall } from "@/hooks/usePWAInstall";
+import { trackEvent } from "@/lib/gtag";
+import { css } from "@styled-system/css";
+import { IconDownload } from "@tabler/icons-react";
+import Image from "next/image";
+import { useState } from "react";
+import { PWAInstallInstructions } from "./PWAInstallInstructions";
+
+export function PWAInstallBanner() {
+  const { state, promptInstall, dismiss } = usePWAInstall();
+  const [showIOSInstructions, setShowIOSInstructions] = useState(false);
+
+  if (state === "hidden") {
+    return showIOSInstructions ? (
+      <PWAInstallInstructions onClose={() => setShowIOSInstructions(false)} />
+    ) : null;
+  }
+
+  const handleInstall = () => {
+    trackEvent("pwa_install_banner_click", { platform: state });
+    if (state === "android") {
+      void promptInstall();
+    } else {
+      setShowIOSInstructions(true);
+    }
+  };
+
+  return (
+    <>
+      <div
+        role="dialog"
+        aria-label="앱 설치 안내"
+        className={css({
+          position: "fixed",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          padding: "12px 16px calc(12px + env(safe-area-inset-bottom, 0px))",
+          zIndex: 1050,
+          pointerEvents: "none",
+        })}
+      >
+        <div
+          className={`card ${css({
+            pointerEvents: "auto",
+            maxWidth: "480px",
+            margin: "0 auto",
+            boxShadow: "0 8px 24px rgba(0, 0, 0, 0.18)",
+            border: "1px solid #e5e5e5",
+          })}`}
+        >
+          <div
+            className={`card-body ${css({
+              display: "flex",
+              alignItems: "center",
+              gap: "12px",
+              padding: "12px 14px !important",
+            })}`}
+          >
+            <Image
+              src="/logo.svg"
+              alt="다이소 파인더"
+              width={40}
+              height={40}
+              className={css({ flexShrink: 0 })}
+            />
+            <div className={css({ flex: 1, minWidth: 0 })}>
+              <div
+                className={css({
+                  fontWeight: 600,
+                  fontSize: "14px",
+                  marginBottom: "2px",
+                })}
+              >
+                앱으로 더 빠르게 찾기
+              </div>
+              <div
+                className={css({
+                  fontSize: "12px",
+                  color: "#6c757d",
+                  lineHeight: 1.4,
+                })}
+              >
+                홈 화면에 추가하고 매장과 상품을 바로 검색하세요
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={handleInstall}
+              className={`btn btn-red ${css({
+                flexShrink: 0,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "4px",
+              })}`}
+            >
+              <IconDownload width={16} height={16} />
+              설치
+            </button>
+            <button
+              type="button"
+              aria-label="닫기"
+              onClick={dismiss}
+              className={`btn-close ${css({ flexShrink: 0 })}`}
+            />
+          </div>
+        </div>
+      </div>
+      {showIOSInstructions && (
+        <PWAInstallInstructions onClose={() => setShowIOSInstructions(false)} />
+      )}
+    </>
+  );
+}

--- a/src/components/PWAInstallInstructions.tsx
+++ b/src/components/PWAInstallInstructions.tsx
@@ -2,35 +2,49 @@
 
 import { trackEvent } from "@/lib/gtag";
 import { css } from "@styled-system/css";
-import {
-  IconCirclePlus,
-  IconDeviceMobile,
-  IconShare3,
-} from "@tabler/icons-react";
-import { useEffect } from "react";
+import type { Icon } from "@tabler/icons-react";
+import { useEffect, useRef } from "react";
+
+export interface PWAInstallStep {
+  icon: Icon;
+  text: string;
+}
 
 interface PWAInstallInstructionsProps {
+  title: string;
+  description: string;
+  steps: PWAInstallStep[];
+  viewEvent: string;
   onClose: () => void;
 }
 
-const steps = [
-  {
-    icon: IconShare3,
-    text: "Safari 하단의 공유 버튼을 탭하세요",
-  },
-  {
-    icon: IconCirclePlus,
-    text: "메뉴에서 '홈 화면에 추가'를 선택하세요",
-  },
-  {
-    icon: IconDeviceMobile,
-    text: "우측 상단의 '추가' 버튼을 탭하면 완료됩니다",
-  },
-];
+const LIGHT_THEME_COLOR = "#FFFFFF";
 
-export function PWAInstallInstructions({ onClose }: PWAInstallInstructionsProps) {
+export function PWAInstallInstructions({
+  title,
+  description,
+  steps,
+  viewEvent,
+  onClose,
+}: PWAInstallInstructionsProps) {
+  const originalThemeColorRef = useRef<string | null>(null);
+
   useEffect(() => {
-    trackEvent("pwa_install_ios_modal_view");
+    trackEvent(viewEvent);
+  }, [viewEvent]);
+
+  useEffect(() => {
+    const meta = document.querySelector<HTMLMetaElement>(
+      'meta[name="theme-color"]',
+    );
+    if (!meta) return;
+    originalThemeColorRef.current = meta.getAttribute("content");
+    meta.setAttribute("content", LIGHT_THEME_COLOR);
+    return () => {
+      if (originalThemeColorRef.current !== null) {
+        meta.setAttribute("content", originalThemeColorRef.current);
+      }
+    };
   }, []);
 
   return (
@@ -40,13 +54,12 @@ export function PWAInstallInstructions({ onClose }: PWAInstallInstructionsProps)
       >
         <div className="modal-content">
           <div className="modal-header">
-            <h5 className="modal-title">홈 화면에 추가하기</h5>
+            <h5 className="modal-title">{title}</h5>
             <button type="button" className="btn-close" onClick={onClose} />
           </div>
           <div className="modal-body">
             <p className={css({ marginBottom: "16px", color: "#4a4a4a" })}>
-              다이소 파인더를 앱처럼 사용해보세요. 아래 단계대로 따라하시면
-              홈 화면에 추가됩니다.
+              {description}
             </p>
             <ol
               className={css({

--- a/src/components/PWAInstallInstructions.tsx
+++ b/src/components/PWAInstallInstructions.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { trackEvent } from "@/lib/gtag";
+import { css } from "@styled-system/css";
+import {
+  IconCirclePlus,
+  IconDeviceMobile,
+  IconShare3,
+} from "@tabler/icons-react";
+import { useEffect } from "react";
+
+interface PWAInstallInstructionsProps {
+  onClose: () => void;
+}
+
+const steps = [
+  {
+    icon: IconShare3,
+    text: "Safari 하단의 공유 버튼을 탭하세요",
+  },
+  {
+    icon: IconCirclePlus,
+    text: "메뉴에서 '홈 화면에 추가'를 선택하세요",
+  },
+  {
+    icon: IconDeviceMobile,
+    text: "우측 상단의 '추가' 버튼을 탭하면 완료됩니다",
+  },
+];
+
+export function PWAInstallInstructions({ onClose }: PWAInstallInstructionsProps) {
+  useEffect(() => {
+    trackEvent("pwa_install_ios_modal_view");
+  }, []);
+
+  return (
+    <div className="modal modal-blur show" style={{ display: "block" }}>
+      <div
+        className={`modal-dialog modal-sm modal-dialog-centered ${css({ maxWidth: "400px", margin: "0 auto", position: "relative", zIndex: 1060 })}`}
+      >
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title">홈 화면에 추가하기</h5>
+            <button type="button" className="btn-close" onClick={onClose} />
+          </div>
+          <div className="modal-body">
+            <p className={css({ marginBottom: "16px", color: "#4a4a4a" })}>
+              다이소 파인더를 앱처럼 사용해보세요. 아래 단계대로 따라하시면
+              홈 화면에 추가됩니다.
+            </p>
+            <ol
+              className={css({
+                display: "flex",
+                flexDirection: "column",
+                gap: "12px",
+                padding: 0,
+                margin: 0,
+                listStyle: "none",
+              })}
+            >
+              {steps.map((step, index) => {
+                const Icon = step.icon;
+                return (
+                  <li
+                    key={index}
+                    className={css({
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "12px",
+                    })}
+                  >
+                    <span
+                      className={css({
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        flexShrink: 0,
+                        width: "28px",
+                        height: "28px",
+                        borderRadius: "50%",
+                        backgroundColor: "#ED1C24",
+                        color: "white",
+                        fontWeight: 600,
+                        fontSize: "14px",
+                      })}
+                    >
+                      {index + 1}
+                    </span>
+                    <Icon
+                      width={22}
+                      height={22}
+                      className={css({ color: "#ED1C24", flexShrink: 0 })}
+                    />
+                    <span className={css({ fontSize: "14px", lineHeight: 1.5 })}>
+                      {step.text}
+                    </span>
+                  </li>
+                );
+              })}
+            </ol>
+          </div>
+          <div className="modal-footer">
+            <button
+              type="button"
+              className="btn btn-red w-100"
+              onClick={onClose}
+            >
+              확인
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="modal-backdrop show" onClick={onClose} />
+    </div>
+  );
+}

--- a/src/components/PWAInstallInstructions.tsx
+++ b/src/components/PWAInstallInstructions.tsx
@@ -3,7 +3,7 @@
 import { trackEvent } from "@/lib/gtag";
 import { css } from "@styled-system/css";
 import type { Icon } from "@tabler/icons-react";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 export interface PWAInstallStep {
   icon: Icon;
@@ -27,23 +27,17 @@ export function PWAInstallInstructions({
   viewEvent,
   onClose,
 }: PWAInstallInstructionsProps) {
-  const originalThemeColorRef = useRef<string | null>(null);
-
   useEffect(() => {
     trackEvent(viewEvent);
   }, [viewEvent]);
 
   useEffect(() => {
-    const meta = document.querySelector<HTMLMetaElement>(
-      'meta[name="theme-color"]',
-    );
-    if (!meta) return;
-    originalThemeColorRef.current = meta.getAttribute("content");
-    meta.setAttribute("content", LIGHT_THEME_COLOR);
+    const override = document.createElement("meta");
+    override.name = "theme-color";
+    override.content = LIGHT_THEME_COLOR;
+    document.head.appendChild(override);
     return () => {
-      if (originalThemeColorRef.current !== null) {
-        meta.setAttribute("content", originalThemeColorRef.current);
-      }
+      override.remove();
     };
   }, []);
 
@@ -123,7 +117,11 @@ export function PWAInstallInstructions({
           </div>
         </div>
       </div>
-      <div className="modal-backdrop show" onClick={onClose} />
+      <div
+        className="modal-backdrop show"
+        onClick={onClose}
+        style={{ backgroundColor: "transparent", opacity: 1 }}
+      />
     </div>
   );
 }

--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { trackEvent } from "@/lib/gtag";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+type PWAInstallState = "hidden" | "android" | "ios";
+
+const DISMISS_STORAGE_KEY = "pwa-install-dismissed-at";
+const DISMISS_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
+const SHOW_DELAY_MS = 3000;
+
+function isWithinDismissWindow(): boolean {
+  try {
+    const raw = window.localStorage.getItem(DISMISS_STORAGE_KEY);
+    if (!raw) return false;
+    const dismissedAt = Number(raw);
+    if (!Number.isFinite(dismissedAt)) return false;
+    return Date.now() - dismissedAt < DISMISS_DURATION_MS;
+  } catch {
+    return false;
+  }
+}
+
+function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  if (window.matchMedia?.("(display-mode: standalone)").matches) return true;
+  // iOS Safari standalone flag
+  return (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+}
+
+function isIOSSafari(): boolean {
+  if (typeof window === "undefined") return false;
+  const ua = window.navigator.userAgent;
+  const isIOS = /iPad|iPhone|iPod/.test(ua);
+  const isNonSafariIOS = /CriOS|FxiOS|EdgiOS|OPiOS/.test(ua);
+  return isIOS && !isNonSafariIOS;
+}
+
+export function usePWAInstall() {
+  const [state, setState] = useState<PWAInstallState>("hidden");
+  const deferredPromptRef = useRef<BeforeInstallPromptEvent | null>(null);
+  const hasTrackedViewRef = useRef(false);
+
+  useEffect(() => {
+    if (isStandalone() || isWithinDismissWindow()) return;
+
+    let cancelled = false;
+    let delayTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      deferredPromptRef.current = event as BeforeInstallPromptEvent;
+      delayTimer = setTimeout(() => {
+        if (!cancelled) setState("android");
+      }, SHOW_DELAY_MS);
+    };
+
+    const handleAppInstalled = () => {
+      deferredPromptRef.current = null;
+      setState("hidden");
+      trackEvent("pwa_installed");
+    };
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+    window.addEventListener("appinstalled", handleAppInstalled);
+
+    if (isIOSSafari()) {
+      delayTimer = setTimeout(() => {
+        if (!cancelled) setState("ios");
+      }, SHOW_DELAY_MS);
+    }
+
+    return () => {
+      cancelled = true;
+      if (delayTimer) clearTimeout(delayTimer);
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+      window.removeEventListener("appinstalled", handleAppInstalled);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (state === "hidden" || hasTrackedViewRef.current) return;
+    hasTrackedViewRef.current = true;
+    trackEvent("pwa_install_banner_view", { platform: state });
+  }, [state]);
+
+  const promptInstall = useCallback(async () => {
+    const deferred = deferredPromptRef.current;
+    if (!deferred) return;
+    deferredPromptRef.current = null;
+    await deferred.prompt();
+    const choice = await deferred.userChoice;
+    trackEvent("pwa_install_prompt_result", { outcome: choice.outcome });
+    setState("hidden");
+  }, []);
+
+  const dismiss = useCallback(() => {
+    try {
+      window.localStorage.setItem(DISMISS_STORAGE_KEY, String(Date.now()));
+    } catch {
+      // localStorage may be unavailable (private mode); silently ignore
+    }
+    setState((prev) => {
+      if (prev !== "hidden") {
+        trackEvent("pwa_install_banner_dismiss", { platform: prev });
+      }
+      return "hidden";
+    });
+  }, []);
+
+  return { state, promptInstall, dismiss };
+}

--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -29,7 +29,6 @@ function isWithinDismissWindow(): boolean {
 function isStandalone(): boolean {
   if (typeof window === "undefined") return false;
   if (window.matchMedia?.("(display-mode: standalone)").matches) return true;
-  // iOS Safari standalone flag
   return (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
 }
 
@@ -43,6 +42,7 @@ function isIOSSafari(): boolean {
 
 export function usePWAInstall() {
   const [state, setState] = useState<PWAInstallState>("hidden");
+  const [hasDeferredPrompt, setHasDeferredPrompt] = useState(false);
   const deferredPromptRef = useRef<BeforeInstallPromptEvent | null>(null);
   const hasTrackedViewRef = useRef(false);
 
@@ -50,18 +50,17 @@ export function usePWAInstall() {
     if (isStandalone() || isWithinDismissWindow()) return;
 
     let cancelled = false;
-    let delayTimer: ReturnType<typeof setTimeout> | null = null;
+    const targetState: PWAInstallState = isIOSSafari() ? "ios" : "android";
 
     const handleBeforeInstallPrompt = (event: Event) => {
       event.preventDefault();
       deferredPromptRef.current = event as BeforeInstallPromptEvent;
-      delayTimer = setTimeout(() => {
-        if (!cancelled) setState("android");
-      }, SHOW_DELAY_MS);
+      setHasDeferredPrompt(true);
     };
 
     const handleAppInstalled = () => {
       deferredPromptRef.current = null;
+      setHasDeferredPrompt(false);
       setState("hidden");
       trackEvent("pwa_installed");
     };
@@ -69,15 +68,13 @@ export function usePWAInstall() {
     window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
     window.addEventListener("appinstalled", handleAppInstalled);
 
-    if (isIOSSafari()) {
-      delayTimer = setTimeout(() => {
-        if (!cancelled) setState("ios");
-      }, SHOW_DELAY_MS);
-    }
+    const delayTimer = setTimeout(() => {
+      if (!cancelled) setState(targetState);
+    }, SHOW_DELAY_MS);
 
     return () => {
       cancelled = true;
-      if (delayTimer) clearTimeout(delayTimer);
+      clearTimeout(delayTimer);
       window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
       window.removeEventListener("appinstalled", handleAppInstalled);
     };
@@ -89,14 +86,16 @@ export function usePWAInstall() {
     trackEvent("pwa_install_banner_view", { platform: state });
   }, [state]);
 
-  const promptInstall = useCallback(async () => {
+  const promptInstall = useCallback(async (): Promise<boolean> => {
     const deferred = deferredPromptRef.current;
-    if (!deferred) return;
+    if (!deferred) return false;
     deferredPromptRef.current = null;
+    setHasDeferredPrompt(false);
     await deferred.prompt();
     const choice = await deferred.userChoice;
     trackEvent("pwa_install_prompt_result", { outcome: choice.outcome });
     setState("hidden");
+    return true;
   }, []);
 
   const dismiss = useCallback(() => {
@@ -113,5 +112,5 @@ export function usePWAInstall() {
     });
   }, []);
 
-  return { state, promptInstall, dismiss };
+  return { state, hasDeferredPrompt, promptInstall, dismiss };
 }


### PR DESCRIPTION
## Summary
Implements a PWA install banner that prompts users to install the app on their home screen. The banner detects the platform (Android via `beforeinstallprompt` event, iOS Safari via user agent) and shows appropriate installation instructions.

## Key Changes
- **`usePWAInstall` hook** — Manages PWA installation state and logic:
  - Detects Android devices via `beforeinstallprompt` event and triggers native install prompt
  - Detects iOS Safari and shows manual installation instructions
  - Respects standalone mode (already installed) and dismissal window (7 days)
  - Tracks analytics events for banner views, clicks, dismissals, and installation outcomes
  
- **`PWAInstallBanner` component** — Displays a fixed bottom banner with:
  - App logo, title, and description
  - Install button that triggers platform-specific flows
  - Close button with 7-day dismissal persistence
  - Conditional rendering of iOS instructions modal
  
- **`PWAInstallInstructions` component** — Modal showing step-by-step iOS installation guide:
  - Visual steps with Tabler icons (share, add to home screen, confirm)
  - Tracks modal view analytics
  
- **Updated `manifest.json`** — Enhanced PWA metadata:
  - Korean localization (name, short_name, description, lang)
  - Added scope and description for better app discoverability
  
- **Updated `layout.tsx`** — Added Apple Web App meta tags:
  - `capable: true` to enable standalone mode on iOS
  - Custom title and status bar styling
  
- **Updated `provider.tsx`** — Integrated `PWAInstallBanner` component into root provider

## Implementation Details
- Uses localStorage to track dismissal timestamp with 7-day window
- Delays banner display by 3 seconds to avoid interrupting initial page load
- Handles edge cases: private browsing mode (localStorage unavailable), already-installed apps, cleanup on unmount
- Analytics integration via `trackEvent()` for monitoring installation funnel
- Fully accessible with proper ARIA labels and semantic HTML

https://claude.ai/code/session_01TQWUXYFMFjwkPBCMrAfMb8