### PR TITLE
Show recently visited branches on the home page

### DIFF
--- a/src/app/branch/[code]/BranchClient.tsx
+++ b/src/app/branch/[code]/BranchClient.tsx
@@ -6,6 +6,7 @@ import {
   SimplifiedProduct,
 } from "@/app/api/products/types";
 import { Search } from "@/components/Search";
+import { useRecentBranches } from "@/hooks/useRecentBranches";
 import { trackEvent } from "@/lib/gtag";
 import { css } from "@styled-system/css";
 import { IconMapPin, IconPhotoX, IconStairs } from "@tabler/icons-react";
@@ -16,7 +17,7 @@ import {
 } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface Props {
   code: string;
@@ -26,6 +27,7 @@ interface Props {
 export function BranchClient({ code, initialBranch }: Props) {
   const [searchInput, setSearchInput] = useState("");
   const [keyword, setKeyword] = useState("");
+  const { addRecentBranch } = useRecentBranches();
 
   const { data: branch } = useQuery<SimplifiedBranch>({
     queryKey: ["branch", code],
@@ -42,6 +44,10 @@ export function BranchClient({ code, initialBranch }: Props) {
     },
     initialData: initialBranch ?? undefined,
   });
+
+  useEffect(() => {
+    if (branch) addRecentBranch(branch);
+  }, [branch, addRecentBranch]);
 
   const {
     data,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { css } from "@styled-system/css";
 import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
-import { IconHistory, IconMapPinFilled, IconX } from "@tabler/icons-react";
+import { IconHistory, IconX } from "@tabler/icons-react";
 import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
@@ -11,11 +11,6 @@ import { SimplifiedBranchResponse } from "./api/branches/types";
 import { Search } from "@/components/Search";
 import { useRecentBranches } from "@/hooks/useRecentBranches";
 import { trackEvent } from "@/lib/gtag";
-import { popularBranches } from "@/lib/seoBranches";
-
-const APP_URL = (
-  process.env.NEXT_PUBLIC_APP_URL || "https://daiso-finder.kr"
-).replace(/\/$/, "");
 
 export default function Home() {
   const [searchInput, setSearchInput] = useState("");
@@ -66,17 +61,6 @@ export default function Home() {
     () => data?.pages.flatMap((page) => page) ?? [],
     [data],
   );
-  const popularBranchesJsonLd = {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: "다이소 주요 인기 매장 바로가기",
-    itemListElement: popularBranches.map((branch, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      name: `다이소 ${branch.name} 재고 확인`,
-      url: `${APP_URL}/branch/${branch.code}`,
-    })),
-  };
 
   const getCurrentPosition = async () => {
     if (!navigator.geolocation) {
@@ -180,12 +164,6 @@ export default function Home() {
         flexDirection: "column",
       })}
     >
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(popularBranchesJsonLd),
-        }}
-      />
       <Image
         src="/logo.svg"
         alt="다이소 파인더 로고"
@@ -218,105 +196,9 @@ export default function Home() {
         errorMessage={isError ? error.message : undefined}
         onRetry={keyword ? () => refetch() : undefined}
         beforeForm={
-          <>
-            {recentBranches.length > 0 && (
-              <nav
-                aria-label="최근 본 다이소 매장"
-                className={css({
-                  display: "flex",
-                  gap: "10px",
-                  overflowX: "auto",
-                  paddingBlock: 4,
-                  paddingInline: 4,
-                  marginBottom: "6px",
-                  scrollbarWidth: "none",
-                  WebkitMaskImage:
-                    "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
-                  maskImage:
-                    "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
-                  "&::-webkit-scrollbar": { display: "none" },
-                })}
-              >
-                <span
-                  aria-hidden="true"
-                  className={css({
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: "4px",
-                    flexShrink: 0,
-                    color: "#666",
-                    fontSize: "0.8125rem",
-                    fontWeight: 500,
-                  })}
-                >
-                  <IconHistory width={15} height={15} />
-                  최근
-                </span>
-                {recentBranches.map((branch) => (
-                  <span
-                    key={branch.code}
-                    className={clsx(
-                      "badge bg-blue-lt",
-                      css({
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: "4px",
-                        flexShrink: 0,
-                        minHeight: "32px",
-                        padding: "4px 4px 4px 11px",
-                        fontSize: "0.875rem",
-                        lineHeight: 1.2,
-                      }),
-                    )}
-                  >
-                    <Link
-                      href={`/branch/${branch.code}`}
-                      onClick={() =>
-                        trackEvent("recent_branch_click", {
-                          branch_code: branch.code,
-                          branch_name: branch.name,
-                        })
-                      }
-                      className={css({
-                        color: "inherit",
-                        textDecoration: "none",
-                      })}
-                    >
-                      {branch.name}
-                    </Link>
-                    <button
-                      type="button"
-                      aria-label={`${branch.name} 최근 본 매장에서 제거`}
-                      onClick={() => {
-                        removeRecentBranch(branch.code);
-                        trackEvent("recent_branch_remove", {
-                          branch_code: branch.code,
-                        });
-                      }}
-                      className={css({
-                        display: "inline-flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        width: "20px",
-                        height: "20px",
-                        padding: 0,
-                        border: "none",
-                        borderRadius: "50%",
-                        backgroundColor: "transparent",
-                        color: "inherit",
-                        cursor: "pointer",
-                        opacity: 0.7,
-                        _hover: { opacity: 1 },
-                      })}
-                    >
-                      <IconX width={14} height={14} />
-                    </button>
-                  </span>
-                ))}
-              </nav>
-            )}
+          recentBranches.length > 0 ? (
             <nav
-              aria-label="주요 다이소 매장"
+              aria-label="최근 본 다이소 매장"
               className={css({
                 display: "flex",
                 gap: "10px",
@@ -332,38 +214,84 @@ export default function Home() {
                 "&::-webkit-scrollbar": { display: "none" },
               })}
             >
-              {popularBranches.map((branch) => (
-                <Link
+              <span
+                aria-hidden="true"
+                className={css({
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "4px",
+                  flexShrink: 0,
+                  color: "#666",
+                  fontSize: "0.8125rem",
+                  fontWeight: 500,
+                })}
+              >
+                <IconHistory width={15} height={15} />
+                최근
+              </span>
+              {recentBranches.map((branch) => (
+                <span
                   key={branch.code}
-                  href={`/branch/${branch.code}`}
                   className={clsx(
-                    "badge bg-red-lt",
+                    "badge bg-blue-lt",
                     css({
                       display: "inline-flex",
                       alignItems: "center",
-                      gap: "6px",
+                      gap: "4px",
                       flexShrink: 0,
                       minHeight: "32px",
-                      padding: "7px 11px",
+                      padding: "4px 4px 4px 11px",
                       fontSize: "0.875rem",
                       lineHeight: 1.2,
                     }),
                   )}
                 >
-                  <IconMapPinFilled
-                    aria-hidden="true"
-                    width={15}
-                    height={15}
+                  <Link
+                    href={`/branch/${branch.code}`}
+                    onClick={() =>
+                      trackEvent("recent_branch_click", {
+                        branch_code: branch.code,
+                        branch_name: branch.name,
+                      })
+                    }
                     className={css({
-                      color: "#ED1C24",
-                      flexShrink: 0,
+                      color: "inherit",
+                      textDecoration: "none",
                     })}
-                  />
-                  {branch.name}
-                </Link>
+                  >
+                    {branch.name}
+                  </Link>
+                  <button
+                    type="button"
+                    aria-label={`${branch.name} 최근 본 매장에서 제거`}
+                    onClick={() => {
+                      removeRecentBranch(branch.code);
+                      trackEvent("recent_branch_remove", {
+                        branch_code: branch.code,
+                      });
+                    }}
+                    className={css({
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      width: "20px",
+                      height: "20px",
+                      padding: 0,
+                      border: "none",
+                      borderRadius: "50%",
+                      backgroundColor: "transparent",
+                      color: "inherit",
+                      cursor: "pointer",
+                      opacity: 0.7,
+                      _hover: { opacity: 1 },
+                    })}
+                  >
+                    <IconX width={14} height={14} />
+                  </button>
+                </span>
               ))}
             </nav>
-          </>
+          ) : undefined
         }
       >
         {branches?.map((branch) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,13 +2,14 @@
 
 import { css } from "@styled-system/css";
 import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
-import { IconMapPinFilled } from "@tabler/icons-react";
+import { IconHistory, IconMapPinFilled, IconX } from "@tabler/icons-react";
 import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { SimplifiedBranchResponse } from "./api/branches/types";
 import { Search } from "@/components/Search";
+import { useRecentBranches } from "@/hooks/useRecentBranches";
 import { trackEvent } from "@/lib/gtag";
 import { popularBranches } from "@/lib/seoBranches";
 
@@ -24,6 +25,7 @@ export default function Home() {
     curLttd: number;
   } | null>(null);
   const ref = useRef<HTMLDivElement>(null);
+  const { recentBranches, removeRecentBranch } = useRecentBranches();
   const { data, error, fetchNextPage, isError, isFetching, refetch } =
     useInfiniteQuery<
       SimplifiedBranchResponse,
@@ -216,54 +218,152 @@ export default function Home() {
         errorMessage={isError ? error.message : undefined}
         onRetry={keyword ? () => refetch() : undefined}
         beforeForm={
-          <nav
-            aria-label="주요 다이소 매장"
-            className={css({
-              display: "flex",
-              gap: "10px",
-              overflowX: "auto",
-              paddingBlock: 4,
-              paddingInline: 4,
-              marginBottom: "10px",
-              scrollbarWidth: "none",
-              WebkitMaskImage:
-                "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
-              maskImage:
-                "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
-              "&::-webkit-scrollbar": { display: "none" },
-            })}
-          >
-            {popularBranches.map((branch) => (
-              <Link
-                key={branch.code}
-                href={`/branch/${branch.code}`}
-                className={clsx(
-                  "badge bg-red-lt",
-                  css({
+          <>
+            {recentBranches.length > 0 && (
+              <nav
+                aria-label="최근 본 다이소 매장"
+                className={css({
+                  display: "flex",
+                  gap: "10px",
+                  overflowX: "auto",
+                  paddingBlock: 4,
+                  paddingInline: 4,
+                  marginBottom: "6px",
+                  scrollbarWidth: "none",
+                  WebkitMaskImage:
+                    "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
+                  maskImage:
+                    "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
+                  "&::-webkit-scrollbar": { display: "none" },
+                })}
+              >
+                <span
+                  aria-hidden="true"
+                  className={css({
                     display: "inline-flex",
                     alignItems: "center",
-                    gap: "6px",
+                    gap: "4px",
                     flexShrink: 0,
-                    minHeight: "32px",
-                    padding: "7px 11px",
-                    fontSize: "0.875rem",
-                    lineHeight: 1.2,
-                  }),
-                )}
-              >
-                <IconMapPinFilled
-                  aria-hidden="true"
-                  width={15}
-                  height={15}
-                  className={css({
-                    color: "#ED1C24",
-                    flexShrink: 0,
+                    color: "#666",
+                    fontSize: "0.8125rem",
+                    fontWeight: 500,
                   })}
-                />
-                {branch.name}
-              </Link>
-            ))}
-          </nav>
+                >
+                  <IconHistory width={15} height={15} />
+                  최근
+                </span>
+                {recentBranches.map((branch) => (
+                  <span
+                    key={branch.code}
+                    className={clsx(
+                      "badge bg-blue-lt",
+                      css({
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: "4px",
+                        flexShrink: 0,
+                        minHeight: "32px",
+                        padding: "4px 4px 4px 11px",
+                        fontSize: "0.875rem",
+                        lineHeight: 1.2,
+                      }),
+                    )}
+                  >
+                    <Link
+                      href={`/branch/${branch.code}`}
+                      onClick={() =>
+                        trackEvent("recent_branch_click", {
+                          branch_code: branch.code,
+                          branch_name: branch.name,
+                        })
+                      }
+                      className={css({
+                        color: "inherit",
+                        textDecoration: "none",
+                      })}
+                    >
+                      {branch.name}
+                    </Link>
+                    <button
+                      type="button"
+                      aria-label={`${branch.name} 최근 본 매장에서 제거`}
+                      onClick={() => {
+                        removeRecentBranch(branch.code);
+                        trackEvent("recent_branch_remove", {
+                          branch_code: branch.code,
+                        });
+                      }}
+                      className={css({
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        width: "20px",
+                        height: "20px",
+                        padding: 0,
+                        border: "none",
+                        borderRadius: "50%",
+                        backgroundColor: "transparent",
+                        color: "inherit",
+                        cursor: "pointer",
+                        opacity: 0.7,
+                        _hover: { opacity: 1 },
+                      })}
+                    >
+                      <IconX width={14} height={14} />
+                    </button>
+                  </span>
+                ))}
+              </nav>
+            )}
+            <nav
+              aria-label="주요 다이소 매장"
+              className={css({
+                display: "flex",
+                gap: "10px",
+                overflowX: "auto",
+                paddingBlock: 4,
+                paddingInline: 4,
+                marginBottom: "10px",
+                scrollbarWidth: "none",
+                WebkitMaskImage:
+                  "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
+                maskImage:
+                  "linear-gradient(90deg, transparent 0, black 14px, black calc(100% - 22px), transparent 100%)",
+                "&::-webkit-scrollbar": { display: "none" },
+              })}
+            >
+              {popularBranches.map((branch) => (
+                <Link
+                  key={branch.code}
+                  href={`/branch/${branch.code}`}
+                  className={clsx(
+                    "badge bg-red-lt",
+                    css({
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "6px",
+                      flexShrink: 0,
+                      minHeight: "32px",
+                      padding: "7px 11px",
+                      fontSize: "0.875rem",
+                      lineHeight: 1.2,
+                    }),
+                  )}
+                >
+                  <IconMapPinFilled
+                    aria-hidden="true"
+                    width={15}
+                    height={15}
+                    className={css({
+                      color: "#ED1C24",
+                      flexShrink: 0,
+                    })}
+                  />
+                  {branch.name}
+                </Link>
+              ))}
+            </nav>
+          </>
         }
       >
         {branches?.map((branch) => (

--- a/src/hooks/useRecentBranches.ts
+++ b/src/hooks/useRecentBranches.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { SimplifiedBranch } from "@/app/api/branches/types";
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "recent-branches";
+const MAX_RECENT_BRANCHES = 5;
+
+function isSimplifiedBranch(value: unknown): value is SimplifiedBranch {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.code === "string" &&
+    typeof v.name === "string" &&
+    typeof v.address === "string" &&
+    typeof v.lat === "number" &&
+    typeof v.lng === "number" &&
+    typeof v.openTime === "string" &&
+    typeof v.closeTime === "string"
+  );
+}
+
+function readFromStorage(): SimplifiedBranch[] {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isSimplifiedBranch).slice(0, MAX_RECENT_BRANCHES);
+  } catch {
+    return [];
+  }
+}
+
+function writeToStorage(branches: SimplifiedBranch[]): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(branches));
+  } catch {
+    // localStorage may be unavailable (private mode); silently ignore
+  }
+}
+
+export function useRecentBranches() {
+  const [recentBranches, setRecentBranches] = useState<SimplifiedBranch[]>([]);
+
+  useEffect(() => {
+    setRecentBranches(readFromStorage());
+  }, []);
+
+  const addRecentBranch = useCallback((branch: SimplifiedBranch) => {
+    setRecentBranches((prev) => {
+      const filtered = prev.filter((b) => b.code !== branch.code);
+      const next = [branch, ...filtered].slice(0, MAX_RECENT_BRANCHES);
+      writeToStorage(next);
+      return next;
+    });
+  }, []);
+
+  const removeRecentBranch = useCallback((code: string) => {
+    setRecentBranches((prev) => {
+      const next = prev.filter((b) => b.code !== code);
+      writeToStorage(next);
+      return next;
+    });
+  }, []);
+
+  return { recentBranches, addRecentBranch, removeRecentBranch };
+}


### PR DESCRIPTION
Persist up to 5 recent branches in localStorage when a user opens a
branch detail page, and surface them as removable chips above the
popular branches list so visitors can jump back to where they were.