### PR TITLE
Redirect www.daiso-finder.kr to the apex domain

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,6 +31,16 @@ const nextConfig = {
       },
     ];
   },
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.daiso-finder.kr" }],
+        destination: "https://daiso-finder.kr/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = withPWA(nextConfig); 


### PR DESCRIPTION
Both www and apex were serving identical HTML, so Google Search Console
treated www.daiso-finder.kr/* as an alternate of the canonical
daiso-finder.kr/* and stopped indexing the www variants. Issue a 301 at
the framework level so the www host never returns content of its own.