### PR TITLE
Revert "Redirect www.daiso-finder.kr to the apex domain"

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -31,16 +31,6 @@ const nextConfig = {
       },
     ];
   },
-  async redirects() {
-    return [
-      {
-        source: "/:path*",
-        has: [{ type: "host", value: "www.daiso-finder.kr" }],
-        destination: "https://daiso-finder.kr/:path*",
-        permanent: true,
-      },
-    ];
-  },
 };
 
 module.exports = withPWA(nextConfig); 


### PR DESCRIPTION
## Summary

Reverts #16 (`ac5b0f6`). 머지 이후 사이트에 접근할 수 없는 회귀가 발생해 즉시 롤백합니다.

원래 의도: `www.daiso-finder.kr/*` → `daiso-finder.kr/*` 301 리다이렉트로 GSC의 "대체 페이지(표준 태그 있음)" 알림 해소. 하지만 배포 환경 도메인/호스트 라우팅 구성과 충돌해 사이트 자체가 닿지 않게 됨.

## Next steps (별도 PR)

- 프로덕션의 실제 호스트 매핑(어떤 도메인이 어디로 들어오는지) 확인
- 리다이렉트는 Next 레벨이 아니라 호스팅(Vercel 등) 도메인 설정에서 처리하거나, `has` 조건을 실제 들어오는 Host 헤더와 매칭되도록 재작성

## Test plan

- [ ] 머지 후 `https://daiso-finder.kr/` 및 `https://www.daiso-finder.kr/` 모두 200 응답 확인
- [ ] `/branch/10528` 접근 가능 확인

https://claude.ai/code/session_01H6NBFPjeo9t7jorPnicJyo

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6NBFPjeo9t7jorPnicJyo)_