### PR TITLE
Add auth.md and fix agent auth discovery endpoints

### DIFF
--- a/public/auth.md
+++ b/public/auth.md
@@ -1,0 +1,27 @@
+# auth.md
+
+> 다이소 파인더 API는 인증 없이 사용 가능한 공개 API입니다. 에이전트 등록이 필요하지 않습니다.
+
+## 에이전트 대상
+
+한국 다이소 매장 검색 및 상품 재고 조회가 필요한 모든 AI 에이전트에게 공개.
+
+## 인증 방식
+
+**익명 (Anonymous)** — 별도 인증 없이 모든 엔드포인트에 접근 가능. API 키, 토큰, 등록 불필요.
+
+## API 엔드포인트
+
+| 엔드포인트 | 설명 |
+|---|---|
+| `GET /api/branches/search` | 키워드 또는 GPS 기반 매장 검색 |
+| `GET /api/branches/[code]` | 매장 단건 조회 |
+| `GET /api/products` | 매장 내 상품 재고 및 진열 위치 검색 |
+| `GET /api/mcp` | MCP 서버 엔드포인트 |
+
+## 에이전트 리소스
+
+- API 카탈로그: `/.well-known/api-catalog`
+- 에이전트 스킬 목록: `/.well-known/agent-skills/index.json`
+- MCP 서버 카드: `/.well-known/mcp/server-card.json`
+- 앱 설명 (Markdown): `/md`

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -10,6 +10,11 @@ export function GET(request: NextRequest) {
       grant_types_supported: [],
       scopes_supported: [],
       token_endpoint_auth_methods_supported: [],
+      agent_auth: {
+        skill: `${base}/.well-known/agent-skills/index.json`,
+        identity_types_supported: ["anonymous"],
+        credential_types_supported: [],
+      },
     },
     {
       headers: {

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -8,7 +8,7 @@ export function GET(request: NextRequest) {
       resource: base,
       authorization_servers: [],
       scopes_supported: [],
-      bearer_methods_supported: [],
+      bearer_methods_supported: ["header"],
       resource_documentation: `${base}/.well-known/api-catalog`,
     },
     {


### PR DESCRIPTION
## Summary

- `public/auth.md` 추가 — [auth.md spec](https://workos.com/auth.md) 준수, 익명 공개 API 기술
- `/.well-known/oauth-protected-resource`: `bearer_methods_supported: ["header"]` 수정
- `/.well-known/oauth-authorization-server`: `agent_auth` 블록 추가 (anonymous identity type, skill pointer)

## DNS-AID 수동 설정 필요

이 PR은 코드 변경만 포함. DNS 레코드는 DNS 프로바이더에서 직접 추가 필요:

```
_index._agents.daiso-finder.kr.  3600  IN  SVCB  1  daiso-finder.kr.  alpn="https"      port=443
_a2a._agents.daiso-finder.kr.    3600  IN  SVCB  1  daiso-finder.kr.  alpn="mcp,h2,h3"  port=443
```

DNSSEC 서명도 DNS 프로바이더 설정에서 활성화 필요 (검증 리졸버 인증 데이터 반환).

## Test plan

- [ ] `https://daiso-finder.kr/auth.md` 접근 시 Markdown 반환 확인
- [ ] `/.well-known/oauth-protected-resource` 응답에 `bearer_methods_supported: ["header"]` 확인
- [ ] `/.well-known/oauth-authorization-server` 응답에 `agent_auth` 블록 확인
- [ ] DNS 레코드 추가 후 `dig _index._agents.daiso-finder.kr SVCB` 확인
- [ ] [isitagentready.com](https://isitagentready.com) 에서 auth.md 및 DNS-AID 체크 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)