### PR TITLE
fix: improve web accessibility

### DIFF
--- a/src/app/branch/[code]/BranchClient.tsx
+++ b/src/app/branch/[code]/BranchClient.tsx
@@ -115,6 +115,7 @@ export function BranchClient({ code, initialBranch }: Props) {
           alt="다이소 파인더 로고"
           width={200}
           height={80}
+          priority
           draggable={false}
           style={{ WebkitUserDrag: "none" } as React.CSSProperties}
           className={css({

--- a/src/app/branch/[code]/BranchClient.tsx
+++ b/src/app/branch/[code]/BranchClient.tsx
@@ -178,6 +178,7 @@ export function BranchClient({ code, initialBranch }: Props) {
         isFetching={isFetching}
         hasResults={products.length > 0}
         keyword={keyword}
+        searchButtonLabel="상품 검색"
         errorMessage={isError ? error.message : undefined}
         onRetry={keyword ? () => refetch() : undefined}
       >
@@ -325,7 +326,7 @@ export function BranchClient({ code, initialBranch }: Props) {
                       className={css({
                         fontWeight: "black",
                         fontSize: "1.25rem",
-                        color: "#ED1C24",
+                        color: "#c4002f",
                         lineHeight: 1,
                         fontVariantNumeric: "tabular-nums",
                       })}
@@ -362,7 +363,7 @@ export function BranchClient({ code, initialBranch }: Props) {
                     </span>
                     <span
                       className={css({
-                        backgroundColor: "#ED1C24",
+                        backgroundColor: "#c4002f",
                         color: "white",
                         padding: "3px 8px",
                         borderRadius: "4px",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -34,6 +34,7 @@ export default function Error({
           alt="다이소 파인더 로고"
           width={200}
           height={80}
+          priority
           draggable={false}
           style={{ WebkitUserDrag: "none" } as React.CSSProperties}
           className={css({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,9 @@
 @import "@tabler/core/dist/css/tabler.min.css";
 
 :root {
+  --daiso-red-accessible: #c4002f;
+  --daiso-red-accessible-hover: #a90029;
+  --daiso-red-accessible-active: #980024;
   --foreground-rgb: 64, 71, 86;
   --background-rgb: 255, 255, 255;
   color-scheme: light;
@@ -28,10 +31,6 @@ body {
 body {
   color: rgb(var(--foreground-rgb));
   overflow: hidden;
-  user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
 }
 
 input,
@@ -47,4 +46,19 @@ textarea,
 a {
   color: inherit;
   text-decoration: none;
+}
+
+.btn.btn-red {
+  --tblr-btn-color: #ffffff;
+  --tblr-btn-bg: var(--daiso-red-accessible);
+  --tblr-btn-border-color: var(--daiso-red-accessible);
+  --tblr-btn-hover-color: #ffffff;
+  --tblr-btn-hover-bg: var(--daiso-red-accessible-hover);
+  --tblr-btn-hover-border-color: var(--daiso-red-accessible-hover);
+  --tblr-btn-active-color: #ffffff;
+  --tblr-btn-active-bg: var(--daiso-red-accessible-active);
+  --tblr-btn-active-border-color: var(--daiso-red-accessible-active);
+  --tblr-btn-disabled-color: #ffffff;
+  --tblr-btn-disabled-bg: var(--daiso-red-accessible);
+  --tblr-btn-disabled-border-color: var(--daiso-red-accessible);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,12 @@
 @layer reset, base, tokens, recipes, utilities;
-@import "@tabler/core/dist/css/tabler.min.css";
 
 :root {
   --daiso-red-accessible: #c4002f;
   --daiso-red-accessible-hover: #a90029;
   --daiso-red-accessible-active: #980024;
+  --daiso-border: #d1d5db;
+  --daiso-surface: #ffffff;
+  --daiso-muted: #4b5563;
   --foreground-rgb: 64, 71, 86;
   --background-rgb: 255, 255, 255;
   color-scheme: light;
@@ -31,6 +33,26 @@ body {
 body {
   color: rgb(var(--foreground-rgb));
   overflow: hidden;
+  margin: 0;
+  font-family:
+    Pretendard,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Apple SD Gothic Neo",
+    "Noto Sans KR",
+    "Malgun Gothic",
+    "Segoe UI",
+    sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.4286;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
 }
 
 input,
@@ -48,17 +70,267 @@ a {
   text-decoration: none;
 }
 
+a:hover {
+  text-decoration: underline;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+img,
+svg {
+  vertical-align: middle;
+}
+
+.text-muted {
+  color: var(--daiso-muted) !important;
+}
+
+.input-group {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.input-group > .form-control {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.input-group > .btn {
+  border-radius: 0;
+  margin-left: -1px;
+}
+
+.input-group > .btn:last-child {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.form-control {
+  display: block;
+  width: 100%;
+  min-height: 40px;
+  padding: 0.4375rem 0.75rem;
+  color: #1f2937;
+  background-color: var(--daiso-surface);
+  border: 1px solid var(--daiso-border);
+  border-radius: 4px;
+  outline: none;
+}
+
+.form-control:focus {
+  border-color: #066fd1;
+  box-shadow: 0 0 0 0.2rem rgba(6, 111, 209, 0.18);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-height: 40px;
+  padding: 0.4375rem 0.875rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-weight: 500;
+  line-height: 1.4286;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 0.25rem rgba(196, 0, 47, 0.25);
+}
+
 .btn.btn-red {
-  --tblr-btn-color: #ffffff;
-  --tblr-btn-bg: var(--daiso-red-accessible);
-  --tblr-btn-border-color: var(--daiso-red-accessible);
-  --tblr-btn-hover-color: #ffffff;
-  --tblr-btn-hover-bg: var(--daiso-red-accessible-hover);
-  --tblr-btn-hover-border-color: var(--daiso-red-accessible-hover);
-  --tblr-btn-active-color: #ffffff;
-  --tblr-btn-active-bg: var(--daiso-red-accessible-active);
-  --tblr-btn-active-border-color: var(--daiso-red-accessible-active);
-  --tblr-btn-disabled-color: #ffffff;
-  --tblr-btn-disabled-bg: var(--daiso-red-accessible);
-  --tblr-btn-disabled-border-color: var(--daiso-red-accessible);
+  color: #ffffff;
+  background-color: var(--daiso-red-accessible);
+  border-color: var(--daiso-red-accessible);
+}
+
+.btn.btn-red:hover {
+  color: #ffffff;
+  background-color: var(--daiso-red-accessible-hover);
+  border-color: var(--daiso-red-accessible-hover);
+  text-decoration: none;
+}
+
+.btn.btn-red:active {
+  color: #ffffff;
+  background-color: var(--daiso-red-accessible-active);
+  border-color: var(--daiso-red-accessible-active);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.btn-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  color: #374151;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-close::before {
+  content: "\00d7";
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.btn-close:hover {
+  background-color: #f3f4f6;
+}
+
+.card {
+  display: block;
+  color: inherit;
+  background-color: var(--daiso-surface);
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.card:hover {
+  text-decoration: none;
+}
+
+.card-body {
+  padding: 1rem;
+}
+
+.card-title {
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.card-text {
+  margin-bottom: 0;
+}
+
+.badge {
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.bg-blue-lt {
+  color: #1d4ed8;
+  background-color: #e7f0ff;
+}
+
+.w-100 {
+  width: 100% !important;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1055;
+  overflow-x: hidden;
+  overflow-y: auto;
+  outline: 0;
+}
+
+.modal-dialog {
+  position: relative;
+  width: auto;
+  margin: 0.5rem;
+  pointer-events: none;
+}
+
+.modal-sm {
+  max-width: 400px;
+}
+
+.modal-dialog-centered {
+  display: flex;
+  min-height: calc(100% - 1rem);
+  align-items: center;
+}
+
+.modal-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  color: #1f2937;
+  pointer-events: auto;
+  background-color: var(--daiso-surface);
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header,
+.modal-footer {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+}
+
+.modal-header {
+  justify-content: space-between;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.modal-body {
+  position: relative;
+  flex: 1 1 auto;
+  padding: 1rem;
+}
+
+.modal-footer {
+  border-top: 1px solid #e5e7eb;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+  background-color: rgba(17, 24, 39, 0.35);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -117,8 +117,6 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
   themeColor: "#ED1C24",
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,5 @@
 import { css } from "@styled-system/css";
-import clsx from "clsx";
 import type { Metadata, Viewport } from "next";
-import localFont from "next/font/local";
 import "./globals.css";
 import { GoogleAnalytics } from "./GoogleAnalytics";
 import Provider from "./provider";
@@ -12,10 +10,6 @@ const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 const APP_URL = (
   process.env.NEXT_PUBLIC_APP_URL || "https://daiso-finder.kr"
 ).replace(/\/$/, "");
-
-const pretendard = localFont({
-  src: "./PretendardVariable.woff2",
-});
 
 const webAppJsonLd = {
   "@context": "https://schema.org",
@@ -128,10 +122,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body
-        className={clsx(
-          pretendard.className,
-          css({ padding: "24px !important", height: "100dvh" }),
-        )}
+        className={css({ padding: "24px !important", height: "100dvh" })}
       >
         <script
           type="application/ld+json"

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -21,6 +21,7 @@ export default function NotFound() {
           alt="다이소 파인더 로고"
           width={200}
           height={80}
+          priority
           draggable={false}
           style={{ WebkitUserDrag: "none" } as React.CSSProperties}
           className={css({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -169,6 +169,7 @@ export default function Home() {
         alt="다이소 파인더 로고"
         width={200}
         height={80}
+        priority
         draggable={false}
         style={{ WebkitUserDrag: "none" } as React.CSSProperties}
         className={css({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -104,8 +104,8 @@ export default function Home() {
   const handleSearch = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const button = (e.nativeEvent as SubmitEvent)
-      .submitter as HTMLButtonElement;
-    const action = button.value;
+      .submitter as HTMLButtonElement | null;
+    const action = button?.value ?? "keyword";
 
     if (action === "location") {
       try {
@@ -193,6 +193,8 @@ export default function Home() {
         hasResults={branches.length > 0}
         keyword={keyword}
         withLocation
+        searchButtonLabel="매장 검색"
+        locationButtonLabel="현재 위치로 주변 매장 검색"
         errorMessage={isError ? error.message : undefined}
         onRetry={keyword ? () => refetch() : undefined}
         beforeForm={
@@ -274,8 +276,8 @@ export default function Home() {
                       display: "inline-flex",
                       alignItems: "center",
                       justifyContent: "center",
-                      width: "20px",
-                      height: "20px",
+                      width: "28px",
+                      height: "28px",
                       padding: 0,
                       border: "none",
                       borderRadius: "50%",
@@ -286,7 +288,7 @@ export default function Home() {
                       _hover: { opacity: 1 },
                     })}
                   >
-                    <IconX width={14} height={14} />
+                    <IconX aria-hidden="true" width={14} height={14} />
                   </button>
                 </span>
               ))}

--- a/src/components/PWAInstallBanner.tsx
+++ b/src/components/PWAInstallBanner.tsx
@@ -161,7 +161,7 @@ export function PWAInstallBanner() {
                 gap: "4px",
               })}`}
             >
-              <IconDownload width={16} height={16} />
+              <IconDownload aria-hidden="true" width={16} height={16} />
               설치
             </button>
             <button

--- a/src/components/PWAInstallInstructions.tsx
+++ b/src/components/PWAInstallInstructions.tsx
@@ -3,7 +3,7 @@
 import { trackEvent } from "@/lib/gtag";
 import { css } from "@styled-system/css";
 import type { Icon } from "@tabler/icons-react";
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
 
 export interface PWAInstallStep {
   icon: Icon;
@@ -27,6 +27,9 @@ export function PWAInstallInstructions({
   viewEvent,
   onClose,
 }: PWAInstallInstructionsProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+
   useEffect(() => {
     trackEvent(viewEvent);
   }, [viewEvent]);
@@ -42,17 +45,34 @@ export function PWAInstallInstructions({
   }, []);
 
   return (
-    <div className="modal modal-blur show" style={{ display: "block" }}>
+    <div
+      className="modal modal-blur show"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      style={{ display: "block" }}
+    >
       <div
         className={`modal-dialog modal-sm modal-dialog-centered ${css({ maxWidth: "400px", margin: "0 auto", position: "relative", zIndex: 1060 })}`}
       >
         <div className="modal-content">
           <div className="modal-header">
-            <h5 className="modal-title">{title}</h5>
-            <button type="button" className="btn-close" onClick={onClose} />
+            <h5 id={titleId} className="modal-title">
+              {title}
+            </h5>
+            <button
+              type="button"
+              className="btn-close"
+              aria-label="닫기"
+              onClick={onClose}
+            />
           </div>
           <div className="modal-body">
-            <p className={css({ marginBottom: "16px", color: "#4a4a4a" })}>
+            <p
+              id={descriptionId}
+              className={css({ marginBottom: "16px", color: "#4a4a4a" })}
+            >
               {description}
             </p>
             <ol
@@ -85,7 +105,7 @@ export function PWAInstallInstructions({
                         width: "28px",
                         height: "28px",
                         borderRadius: "50%",
-                        backgroundColor: "#ED1C24",
+                        backgroundColor: "#c4002f",
                         color: "white",
                         fontWeight: 600,
                         fontSize: "14px",
@@ -94,9 +114,10 @@ export function PWAInstallInstructions({
                       {index + 1}
                     </span>
                     <Icon
+                      aria-hidden="true"
                       width={22}
                       height={22}
-                      className={css({ color: "#ED1C24", flexShrink: 0 })}
+                      className={css({ color: "#c4002f", flexShrink: 0 })}
                     />
                     <span className={css({ fontSize: "14px", lineHeight: 1.5 })}>
                       {step.text}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -8,7 +8,7 @@ import {
   IconSearch,
 } from "@tabler/icons-react";
 import clsx from "clsx";
-import { ReactNode } from "react";
+import { ReactNode, useId } from "react";
 
 interface SearchProps {
   title: string;
@@ -22,6 +22,8 @@ interface SearchProps {
   hasResults?: boolean;
   keyword?: string;
   withLocation?: boolean;
+  searchButtonLabel?: string;
+  locationButtonLabel?: string;
   errorMessage?: string;
   onRetry?: () => void;
 }
@@ -38,14 +40,23 @@ export function Search({
   hasResults,
   keyword,
   withLocation = false,
+  searchButtonLabel = "검색",
+  locationButtonLabel = "현재 위치로 검색",
   errorMessage,
   onRetry,
 }: SearchProps) {
+  const inputId = useId();
   const hasError = Boolean(errorMessage);
+  const statusMessage = isFetching
+    ? "검색 중..."
+    : keyword
+      ? "검색 결과가 없습니다"
+      : "검색어를 입력해주세요";
 
   return (
     <>
-      <span
+      <label
+        htmlFor={inputId}
         className={clsx(
           "text-muted",
           css({
@@ -55,13 +66,15 @@ export function Search({
         )}
       >
         {title}
-      </span>
+      </label>
       {beforeForm}
       <form
         className={clsx("input-group", css({ marginBottom: "12px" }))}
         onSubmit={onSubmit}
+        role="search"
       >
         <input
+          id={inputId}
           type="text"
           className="form-control"
           placeholder={placeholder}
@@ -73,8 +86,9 @@ export function Search({
           type="submit"
           name="action"
           value="keyword"
+          aria-label={searchButtonLabel}
         >
-          <IconSearch width={20} height={20} />
+          <IconSearch aria-hidden="true" width={20} height={20} />
         </button>
         {withLocation && (
           <button
@@ -82,8 +96,9 @@ export function Search({
             name="action"
             value="location"
             type="submit"
+            aria-label={locationButtonLabel}
           >
-            <IconLocation width={20} height={20} />
+            <IconLocation aria-hidden="true" width={20} height={20} />
           </button>
         )}
       </form>
@@ -126,7 +141,7 @@ export function Search({
             </p>
             {onRetry && (
               <button type="button" onClick={onRetry} className="btn btn-red">
-                <IconRefresh width={18} height={18} />
+                <IconRefresh aria-hidden="true" width={18} height={18} />
                 다시 시도
               </button>
             )}
@@ -134,16 +149,14 @@ export function Search({
         ) : (
           !hasResults && (
             <div
+              role="status"
+              aria-live="polite"
               className={clsx(
                 "text-muted",
                 css({ textAlign: "center", marginTop: "16px" }),
               )}
             >
-              {isFetching
-                ? "검색 중..."
-                : keyword
-                  ? "검색 결과가 없습니다"
-                  : "검색어를 입력해주세요"}
+              {statusMessage}
             </div>
           )
         )}

--- a/src/contexts/ErrorModalContext.tsx
+++ b/src/contexts/ErrorModalContext.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { css } from "@styled-system/css";
-import { createContext, useCallback, useContext, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useId,
+  useState,
+} from "react";
 
 interface ErrorModalContextValue {
   showError: (message: string, detail?: string) => void;
@@ -22,6 +28,8 @@ export function ErrorModalProvider({
 }: {
   children: React.ReactNode;
 }) {
+  const titleId = useId();
+  const messageId = useId();
   const [error, setError] = useState<{
     isOpen: boolean;
     message: string;
@@ -43,21 +51,31 @@ export function ErrorModalProvider({
     <ErrorModalContext.Provider value={{ showError }}>
       {children}
       {error.isOpen && (
-        <div className="modal modal-blur show" style={{ display: "block" }}>
+        <div
+          className="modal modal-blur show"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          aria-describedby={messageId}
+          style={{ display: "block" }}
+        >
           <div
             className={`modal-dialog modal-sm modal-dialog-centered ${css({ maxWidth: "400px", margin: "0 auto", position: "relative", zIndex: 1060 })}`}
           >
             <div className="modal-content">
               <div className="modal-header">
-                <h5 className="modal-title">오류</h5>
+                <h5 id={titleId} className="modal-title">
+                  오류
+                </h5>
                 <button
                   type="button"
                   className="btn-close"
+                  aria-label="닫기"
                   onClick={closeError}
                 />
               </div>
               <div className="modal-body">
-                <p>{error.message}</p>
+                <p id={messageId}>{error.message}</p>
                 {error.detail && (
                   <textarea
                     readOnly


### PR DESCRIPTION
## TL;DR

PageSpeed 접근성 리포트에서 실패하던 버튼 이름, viewport zoom 제한, 색 대비 문제를 개선했고, 추가로 보고서의 LCP/렌더 차단 CSS 병목도 함께 줄였습니다.

## 변경사항

### 버그 수정
- 아이콘만 있는 매장/상품 검색 버튼에 접근 가능한 이름을 추가했습니다.
- 검색 입력을 실제 `label`과 연결해 스크린 리더가 입력 목적을 읽을 수 있게 했습니다.
- viewport의 `maximumScale`/`userScalable: false` 설정을 제거해 사용자가 확대할 수 있게 했습니다.
- PWA 설치/에러 모달의 dialog 이름과 닫기 버튼 이름을 보강했습니다.

### 개선사항
- `btn-red` 색상을 접근성 기준을 만족하는 빨강 계열로 조정했습니다.
- 본문 전역 텍스트 선택 차단을 제거했습니다.
- 검색 상태 메시지에 `role="status"`와 `aria-live`를 추가했습니다.
- 전체 Tabler CSS import를 제거하고 실제 사용 중인 최소 스타일만 전역 CSS로 유지해 렌더 차단 CSS와 unused CSS를 줄였습니다.
- 2MB대 로컬 웹폰트 번들 로딩을 제거하고 시스템 폰트 스택으로 대체했습니다.
- 첫 화면 로고 이미지에 `priority`를 적용해 LCP 후보 이미지가 지연 로딩되지 않게 했습니다.

## 주요 변경 파일

- `src/components/Search.tsx`: 검색 폼 label, 버튼 aria-label, live status 추가
- `src/app/layout.tsx`: 사용자 확대 제한 제거, 로컬 웹폰트 번들 제거
- `src/app/globals.css`: 버튼 대비 개선, 전역 user-select 제거, 최소 UI 스타일 정의
- `src/components/PWAInstallInstructions.tsx`: 모달 접근성 속성 보강
- `src/contexts/ErrorModalContext.tsx`: alertdialog 접근성 속성 보강
- `src/app/page.tsx`, `src/app/branch/[code]/BranchClient.tsx`, `src/app/error.tsx`, `src/app/not-found.tsx`: 로고 이미지 priority 적용

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 로컬 브라우저 확인: 버튼 이름 누락 0개, viewport `width=device-width, initial-scale=1`, CSS 1개, 폰트 preload 없음
- [x] 로컬 Lighthouse mobile: Performance 0.99, Accessibility 1.00, LCP 2.1s, render-blocking resources 0ms, unused CSS 0 bytes
