### PR TITLE
[Feat](seo): Add dynamic Open Graph images

### DIFF
--- a/src/app/NotoSansCJKkr-Regular.LICENSE.txt
+++ b/src/app/NotoSansCJKkr-Regular.LICENSE.txt
@@ -1,0 +1,92 @@
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/src/app/branch/[code]/opengraph-image.tsx
+++ b/src/app/branch/[code]/opengraph-image.tsx
@@ -1,0 +1,29 @@
+import { fetchBranchByCode } from "@/lib/daisoBranches";
+import { formatDaisoBranchName } from "@/lib/branchNames";
+import {
+  createDaisoOgImage,
+  ogImageContentType,
+  ogImageSize,
+} from "@/lib/ogImage";
+import { popularBranches } from "@/lib/seoBranches";
+
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const alt = "다이소 지점 상품 찾기";
+
+export default async function Image({ params }: { params: { code: string } }) {
+  const branch = await fetchBranchByCode(params.code).catch(() => null);
+  const fallbackBranch = popularBranches.find(
+    (item) => item.code === params.code,
+  );
+  const branchName = branch?.name ?? fallbackBranch?.name ?? "매장";
+  const branchLabel = formatDaisoBranchName(branchName);
+
+  return createDaisoOgImage({
+    eyebrow: "지점별 상품 검색",
+    title: `${branchLabel}\n에서 물건을 찾아보세요!`,
+    subtitle: "재고, 가격, 진열 위치를 확인하세요.",
+    badge: "지점 검색",
+    footer: `/branch/${params.code}`,
+  });
+}

--- a/src/app/branch/[code]/page.tsx
+++ b/src/app/branch/[code]/page.tsx
@@ -1,4 +1,5 @@
 import { SimplifiedBranch } from "@/app/api/branches/types";
+import { formatDaisoBranchName } from "@/lib/branchNames";
 import { fetchBranchByCode } from "@/lib/daisoBranches";
 import { branchSearchKeywords, popularBranches } from "@/lib/seoBranches";
 import type { Metadata } from "next";
@@ -29,7 +30,8 @@ export async function generateMetadata({
     return { title: "매장 정보를 찾을 수 없습니다" };
   }
 
-  const title = `${branch.name} 상품 재고 확인`;
+  const branchLabel = formatDaisoBranchName(branch.name);
+  const title = `${branchLabel} 상품 찾기`;
   const popularBranch = popularBranches.find(
     (item) => item.code === params.code,
   );
@@ -38,8 +40,9 @@ export async function generateMetadata({
     `${branch.name} 다이소`,
     `${branch.name} 재고 확인`,
   ];
-  const description = `${branch.name}(${branch.address}) 다이소 매장의 상품 재고, 가격, 층별 진열 위치를 확인하세요. 영업시간 ${branch.openTime} ~ ${branch.closeTime}`;
+  const description = `${branchLabel}에서 물건을 찾아보세요! 재고, 가격, 진열 위치를 확인할 수 있습니다.`;
   const url = `${getBaseUrl()}/branch/${params.code}`;
+  const imageUrl = `${url}/opengraph-image`;
 
   return {
     title,
@@ -59,17 +62,18 @@ export async function generateMetadata({
       url,
       images: [
         {
-          url: "/ms-icon-310x310.png",
-          width: 310,
-          height: 310,
-          alt: `다이소 ${branch.name}`,
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: `${branchLabel}에서 물건을 찾아보세요!`,
         },
       ],
     },
     twitter: {
-      card: "summary",
+      card: "summary_large_image",
       title,
       description,
+      images: [imageUrl],
     },
   };
 }
@@ -93,6 +97,7 @@ export default async function BranchPage({
     `${branch.name} 다이소`,
     `${branch.name} 재고 확인`,
   ];
+  const branchLabel = formatDaisoBranchName(branch.name);
   const pageUrl = `${getBaseUrl()}/branch/${params.code}`;
 
   const jsonLd = branch
@@ -102,8 +107,8 @@ export default async function BranchPage({
           {
             "@type": "Store",
             "@id": `${pageUrl}#store`,
-            name: `다이소 ${branch.name}`,
-            description: `다이소 ${branch.name} 매장의 상품 재고, 가격, 진열 위치, 영업시간 정보`,
+            name: branchLabel,
+            description: `${branchLabel}에서 상품 재고, 가격, 진열 위치를 확인할 수 있습니다.`,
             address: {
               "@type": "PostalAddress",
               streetAddress: branch.address,
@@ -127,8 +132,8 @@ export default async function BranchPage({
             "@type": "WebPage",
             "@id": `${pageUrl}#webpage`,
             url: pageUrl,
-            name: `${branch.name} 다이소 상품 재고 확인`,
-            description: `${branch.name} 매장의 다이소 상품 재고, 가격, 층별 진열 위치를 확인하세요.`,
+            name: `${branchLabel} 상품 찾기`,
+            description: `${branchLabel}에서 물건을 찾아보세요! 재고, 가격, 진열 위치를 확인할 수 있습니다.`,
             inLanguage: "ko-KR",
             about: { "@id": `${pageUrl}#store` },
             keywords: [...localKeywords, ...branchSearchKeywords].join(", "),
@@ -146,7 +151,7 @@ export default async function BranchPage({
               {
                 "@type": "ListItem",
                 position: 2,
-                name: `다이소 ${branch.name}`,
+                name: branchLabel,
                 item: pageUrl,
               },
             ],

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import { GoogleAnalytics } from "./GoogleAnalytics";
 import Provider from "./provider";
 import { WebMCP } from "./webmcp";
-import { branchSearchKeywords, popularBranches } from "@/lib/seoBranches";
+import { branchSearchKeywords } from "@/lib/seoBranches";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
 const APP_URL = (
@@ -18,8 +18,7 @@ const webAppJsonLd = {
       "@type": "WebApplication",
       "@id": `${APP_URL}/#webapp`,
       name: "다이소 파인더",
-      description:
-        "다이소 매장의 상품 재고, 가격, 진열 위치를 확인하고 내 주변 매장을 빠르게 찾을 수 있습니다.",
+      description: "다이소 매장의 상품 재고, 가격, 진열 위치를 확인하세요.",
       applicationCategory: "ShoppingApplication",
       operatingSystem: "All",
       offers: { "@type": "Offer", price: "0", priceCurrency: "KRW" },
@@ -31,17 +30,6 @@ const webAppJsonLd = {
       },
       keywords: branchSearchKeywords.join(", "),
     },
-    {
-      "@type": "ItemList",
-      "@id": `${APP_URL}/#popular-branches`,
-      name: "다이소 주요 인기 매장",
-      itemListElement: popularBranches.map((branch, index) => ({
-        "@type": "ListItem",
-        position: index + 1,
-        url: `${APP_URL}/branch/${branch.code}`,
-        name: `다이소 ${branch.name}`,
-      })),
-    },
   ],
 };
 
@@ -51,8 +39,7 @@ export const metadata: Metadata = {
     default: "다이소 상품 찾기 | 다이소 파인더",
     template: "%s | 다이소 파인더",
   },
-  description:
-    "다이소 매장의 상품 재고, 가격, 층별 진열 위치를 확인하세요. 강남역, 명동, 홍대, 신촌, 잠실 등 주요 매장에서 원하는 상품을 빠르게 찾아드립니다.",
+  description: "다이소 매장의 상품 재고, 가격, 진열 위치를 확인하세요.",
   manifest: "/manifest.json",
   applicationName: "다이소 파인더",
   appleWebApp: {
@@ -60,35 +47,30 @@ export const metadata: Metadata = {
     title: "다이소 파인더",
     statusBarStyle: "default",
   },
-  keywords: [
-    "다이소",
-    ...branchSearchKeywords,
-    ...popularBranches.flatMap((branch) => branch.keywords),
-  ],
+  keywords: ["다이소", ...branchSearchKeywords],
   authors: [{ name: "다이소 파인더" }],
   alternates: { canonical: "/" },
   formatDetection: { telephone: false },
   openGraph: {
     title: "다이소 상품 찾기 | 다이소 파인더",
-    description:
-      "다이소 매장의 상품 재고, 가격, 층별 진열 위치를 확인하세요. 내 주변 매장에 원하는 상품이 있는지 빠르게 찾아드립니다.",
+    description: "다이소 매장의 상품 재고, 가격, 진열 위치를 확인하세요.",
     siteName: "다이소 파인더",
     locale: "ko_KR",
     type: "website",
     images: [
       {
-        url: "/ms-icon-310x310.png",
-        width: 310,
-        height: 310,
-        alt: "다이소 파인더",
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "다이소 파인더 - 다이소 상품 찾기",
       },
     ],
   },
   twitter: {
-    card: "summary",
+    card: "summary_large_image",
     title: "다이소 상품 찾기 | 다이소 파인더",
-    description:
-      "다이소 매장의 상품 재고를 실시간으로 확인하세요.",
+    description: "다이소 매장의 상품 재고, 가격, 진열 위치를 확인하세요.",
+    images: ["/opengraph-image"],
   },
   icons: {
     icon: [

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,18 @@
+import {
+  createDaisoOgImage,
+  ogImageContentType,
+  ogImageSize,
+} from "@/lib/ogImage";
+
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const alt = "다이소 파인더 - 다이소 상품 찾기";
+
+export default function Image() {
+  return createDaisoOgImage({
+    eyebrow: "다이소 파인더",
+    title: "다이소 상품 찾기",
+    subtitle: "매장별 재고, 가격, 진열 위치를 빠르게 확인하세요.",
+    badge: "상품 검색",
+  });
+}

--- a/src/lib/branchNames.ts
+++ b/src/lib/branchNames.ts
@@ -1,0 +1,3 @@
+export function formatDaisoBranchName(name: string) {
+  return name.startsWith("다이소") ? name : `다이소 ${name}`;
+}

--- a/src/lib/ogImage.tsx
+++ b/src/lib/ogImage.tsx
@@ -1,0 +1,304 @@
+import { ImageResponse } from "next/og";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { CSSProperties } from "react";
+
+export const ogImageSize = {
+  width: 1200,
+  height: 630,
+};
+
+export const ogImageContentType = "image/png";
+
+type DaisoOgImageOptions = {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  badge: string;
+  footer?: string;
+};
+
+let ogFontPromise: Promise<ArrayBuffer> | null = null;
+
+function getOgFont() {
+  ogFontPromise ??= readFile(
+    join(process.cwd(), "src/app/NotoSansCJKkr-Regular.otf"),
+  ).then((buffer) =>
+    buffer.buffer.slice(
+      buffer.byteOffset,
+      buffer.byteOffset + buffer.byteLength,
+    ),
+  ) as Promise<ArrayBuffer>;
+
+  return ogFontPromise;
+}
+
+function getTitleFontSize(title: string) {
+  const longestLine = Math.max(...title.split("\n").map((line) => line.length));
+
+  if (title.includes("\n")) {
+    if (longestLine >= 16) return 50;
+    if (longestLine >= 11) return 58;
+    return 66;
+  }
+
+  if (longestLine >= 22) return 48;
+  if (longestLine >= 18) return 56;
+  if (longestLine >= 14) return 64;
+  return 86;
+}
+
+const rootStyle = {
+  width: "100%",
+  height: "100%",
+  display: "flex",
+  position: "relative",
+  overflow: "hidden",
+  backgroundColor: "#fbfaf8",
+  color: "#111111",
+  fontFamily: "Noto Sans KR",
+  letterSpacing: 0,
+} satisfies CSSProperties;
+
+const logoMarkStyle = {
+  width: 116,
+  height: 116,
+  borderRadius: 30,
+  backgroundColor: "#ffffff",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  position: "relative",
+} satisfies CSSProperties;
+
+const featureChipStyle = {
+  minWidth: 142,
+  height: 58,
+  padding: "0 22px",
+  border: "1px solid #dedbd5",
+  borderRadius: 999,
+  backgroundColor: "#ffffff",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "#2d2a26",
+  fontSize: 24,
+  fontWeight: 700,
+} satisfies CSSProperties;
+
+export async function createDaisoOgImage({
+  eyebrow,
+  title,
+  subtitle,
+  badge,
+  footer = "daiso-finder.kr",
+}: DaisoOgImageOptions) {
+  const ogFont = await getOgFont();
+  const titleFontSize = getTitleFontSize(title);
+
+  return new ImageResponse(
+    (
+      <div style={rootStyle}>
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 14,
+            backgroundColor: "#ed1c24",
+            display: "flex",
+          }}
+        />
+        <div
+          style={{
+            width: 360,
+            height: "100%",
+            padding: "54px 46px 50px",
+            backgroundColor: "#ed1c24",
+            color: "#ffffff",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={logoMarkStyle}>
+              <div
+                style={{
+                  width: 54,
+                  height: 54,
+                  border: "14px solid #ed1c24",
+                  borderRadius: 999,
+                  display: "flex",
+                }}
+              />
+              <div
+                style={{
+                  position: "absolute",
+                  right: 26,
+                  bottom: 20,
+                  width: 22,
+                  height: 58,
+                  borderRadius: 999,
+                  backgroundColor: "#ed1c24",
+                  transform: "rotate(-45deg)",
+                  display: "flex",
+                }}
+              />
+            </div>
+            <div
+              style={{
+                marginTop: 38,
+                display: "flex",
+                flexDirection: "column",
+                fontSize: 44,
+                lineHeight: 1.02,
+                fontWeight: 900,
+              }}
+            >
+              <span>Daiso</span>
+              <span>Finder</span>
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              fontSize: 22,
+              lineHeight: 1.45,
+              opacity: 0.92,
+            }}
+          >
+            <span>상품 재고</span>
+            <span>가격</span>
+            <span>진열 위치</span>
+          </div>
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            height: "100%",
+            padding: "66px 70px 54px 66px",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                alignSelf: "flex-start",
+                padding: "12px 20px",
+                borderRadius: 999,
+                backgroundColor: "#111111",
+                color: "#ffffff",
+                fontSize: 22,
+                fontWeight: 800,
+              }}
+            >
+              {eyebrow}
+            </div>
+
+            <div
+              style={{
+                marginTop: 38,
+                display: "flex",
+                flexDirection: "column",
+                color: "#111111",
+                fontSize: titleFontSize,
+                lineHeight: 1.08,
+                fontWeight: 900,
+                maxWidth: 770,
+              }}
+            >
+              {title.split("\n").map((line) => (
+                <span key={line} style={{ display: "flex" }}>
+                  {line}
+                </span>
+              ))}
+            </div>
+
+            <div
+              style={{
+                marginTop: 28,
+                display: "flex",
+                maxWidth: 720,
+                color: "#55514b",
+                fontSize: 29,
+                lineHeight: 1.38,
+                fontWeight: 600,
+              }}
+            >
+              {subtitle}
+            </div>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={{ display: "flex", alignItems: "center" }}>
+              {["재고 확인", "가격 보기", "진열 위치"].map((label, index) => (
+                <div
+                  key={label}
+                  style={{
+                    ...featureChipStyle,
+                    marginLeft: index === 0 ? 0 : 14,
+                  }}
+                >
+                  {label}
+                </div>
+              ))}
+              <div
+                style={{
+                  marginLeft: 18,
+                  padding: "0 24px",
+                  height: 58,
+                  borderRadius: 999,
+                  backgroundColor: "#ed1c24",
+                  color: "#ffffff",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 24,
+                  fontWeight: 800,
+                }}
+              >
+                {badge}
+              </div>
+            </div>
+
+            <div
+              style={{
+                marginTop: 34,
+                paddingTop: 24,
+                borderTop: "1px solid #dedbd5",
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                color: "#817a70",
+                fontSize: 22,
+                fontWeight: 700,
+              }}
+            >
+              <span>다이소 파인더</span>
+              <span>{footer}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...ogImageSize,
+      fonts: [
+        {
+          name: "Noto Sans KR",
+          data: ogFont,
+          style: "normal",
+        },
+      ],
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Add 1200x630 dynamic Open Graph cards for the home page and branch detail pages.
- Wire branch metadata to branch-specific OG image URLs and summary_large_image Twitter cards.
- Shorten the site description and remove the popular-branch metadata copy.
- Add Noto Sans CJK KR OTF plus its SIL OFL license for reliable Korean text rendering in ImageResponse.

## Verification
- pnpm lint
- pnpm exec tsc --noEmit --types node,react,react-dom
- pnpm build
- Verified /opengraph-image, /branch/11199/opengraph-image, and /branch/10610/opengraph-image return 1200x630 PNG images locally.

## Notes
- GEO-AUDIT-REPORT.md is an existing untracked local file and was not included.